### PR TITLE
close #19 RasPike上でビルドできるよう修正する

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,13 +1,13 @@
-mkfile_path := $(dir $(lastword $(MAKEFILE_LIST)))
+mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 APPL_COBJS +=
 
 # Shellスクリプトで、moduleディレクトリ中のソースコード名をオブジェクトファイル名に変換している
 APPL_CXXOBJS += $(shell echo \
-                    `ls ${HOME}/etrobo/workspace/etrobocon2022/module/*.cpp | \
+                    `ls ${mkfile_path}module/*.cpp | \
                      sed -r 's/(\/.*)*\/(.*\.)cpp/\2o/g'`)
 APPL_CXXOBJS += $(shell echo \
-                    `ls ${HOME}/etrobo/workspace/etrobocon2022/module/*/*.cpp | \
+                    `ls ${mkfile_path}module/*/*.cpp | \
                      sed -r 's/(\/.*)*\/(.*\.)cpp/\2o/g'`)
 
 SRCLANG := c++


### PR DESCRIPTION
## 完了条件
- [x] 完了条件を満たしている
- [x] GoogleTestが通ることを確認した

## 変更点
- Makefile.inc上のソースファイルのパスを変更

## 動作確認
- 自身の開発環境でmakeできることを確認した
- RasPike上で、サンプルコードとetrobocon2022.cppにprintfを追加したコードについて、ビルド前後で動作が切り替わることを確認した