### PR TITLE
close #30 ビルドチェックが失敗する問題を解決する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update &&\
     apt-get install -y wget git cmake g++
 
 RUN wget https://raw.githubusercontent.com/ETrobocon/etrobo/master/scripts/startetrobo -O ~/startetrobo && \
-    sed -i -r 's/(\s*)sudo((\s+-[a-zA-Z0-9]+)*)?\s+/\1/g' ~/startetrobo && \
+    sed -i -r 's/(\s*)sudo((\s+-[a-zA-Z0-9\-]+)*)?\s+/\1/g' ~/startetrobo && \
     chmod +x ~/startetrobo
 
 # etrobo 環境のセットアップ

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update &&\
     apt-get install -y wget git cmake g++
 
 RUN wget https://raw.githubusercontent.com/ETrobocon/etrobo/master/scripts/startetrobo -O ~/startetrobo && \
-    sed -i -r 's/^(\s*)sudo((\s+-[a-zA-Z0-9]+)*)?/\1/g' ~/startetrobo && \
+    sed -i -r 's/(\s*)sudo((\s+-[a-zA-Z0-9]+)*)?\s+/\1/g' ~/startetrobo && \
     chmod +x ~/startetrobo
 
 # etrobo 環境のセットアップ

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update &&\
     apt-get install -y wget git cmake g++
 
 RUN wget https://raw.githubusercontent.com/ETrobocon/etrobo/master/scripts/startetrobo -O ~/startetrobo && \
-    sed -i -r 's/^(\s*)sudo/\1/g' ~/startetrobo && \
+    sed -i -r 's/^(\s*)sudo((\s+-[a-zA-Z0-9]+)*)?/\1/g' ~/startetrobo && \
     chmod +x ~/startetrobo
 
 # etrobo 環境のセットアップ

--- a/module/Motion/Pid.cpp
+++ b/module/Motion/Pid.cpp
@@ -9,7 +9,7 @@
 PidGain::PidGain(double _kp, double _ki, double _kd) : kp(_kp), ki(_ki), kd(_kd) {}
 
 Pid::Pid(double _kp, double _ki, double _kd, double _targetValue)
-    : gain(_kp, _ki, _kd), preDeviation(0.0), integral(0.0), targetValue(_targetValue)
+  : gain(_kp, _ki, _kd), preDeviation(0.0), integral(0.0), targetValue(_targetValue)
 {
 }
 
@@ -23,8 +23,7 @@ void Pid::setPidGain(double _kp, double _ki, double _kd)
 double Pid::calculatePid(double currentValue, double delta)
 {
   // 0除算を避けるために0の場合はデフォルト周期0.01とする
-  if (delta == 0)
-    delta = 0.01;
+  if(delta == 0) delta = 0.01;
   //現在の偏差を求める
   double currentDeviation = targetValue - currentValue;
   //積分の処理を行う

--- a/module/Motion/Pid.h
+++ b/module/Motion/Pid.h
@@ -8,12 +8,11 @@
 #define PID_H
 
 // PIDゲインを保持する構造体
-struct PidGain
-{
-public:
-  double kp; // Pゲイン
-  double ki; // Iゲイン
-  double kd; // Dゲイン
+struct PidGain {
+ public:
+  double kp;  // Pゲイン
+  double ki;  // Iゲイン
+  double kd;  // Dゲイン
 
   /** コンストラクタ
    * @param _kp Pゲイン
@@ -23,9 +22,8 @@ public:
   PidGain(double _kp, double _ki, double _kd);
 };
 
-class Pid
-{
-public:
+class Pid {
+ public:
   /** コンストラクタ
    * @param _kp Pゲイン
    * @param _ki Iゲイン
@@ -52,11 +50,11 @@ public:
    */
   double calculatePid(double currentValue, double delta = 0.01);
 
-private:
+ private:
   PidGain gain;
-  double preDeviation; //前回の偏差
-  double integral;     //偏差の累積
-  double targetValue;  //目標値
+  double preDeviation;  //前回の偏差
+  double integral;      //偏差の累積
+  double targetValue;   //目標値
 };
 
 #endif

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -7,8 +7,7 @@
 #include "Pid.h"
 #include <gtest/gtest.h>
 
-namespace etrobocon2022_test
-{
+namespace etrobocon2022_test {
   TEST(PidGainTest, gain)
   {
     double expected_p = 0.1;
@@ -137,8 +136,8 @@ namespace etrobocon2022_test
   //周期に0を渡したときに、デフォルト周期0.01として計算されるかをテストする
   TEST(PidTest, calculatePidChangeDeltaZero)
   {
-    constexpr double DELTA = 0;             //実際に渡す周期
-    constexpr double EXPECTED_DELTA = 0.01; //期待される周期
+    constexpr double DELTA = 0;              //実際に渡す周期
+    constexpr double EXPECTED_DELTA = 0.01;  //期待される周期
     double expected_p = 0.6;
     double expected_i = 0.02;
     double expected_d = 0.03;
@@ -166,19 +165,19 @@ namespace etrobocon2022_test
     Pid actualPid(expected_p, expected_i, expected_d, targetValue);
     double currentValue = 60;
     double preDeviation = 0;
-    double currentDiviation = (targetValue - currentValue);            //現在の偏差
-    double p = currentDiviation * expected_p;                          // P制御
-    double i = currentDiviation * DELTA * expected_i;                  // I制御(誤差の累積は0)
-    double d = (currentDiviation - preDeviation) * expected_d / DELTA; // D制御(前回の誤差は0)
+    double currentDiviation = (targetValue - currentValue);  //現在の偏差
+    double p = currentDiviation * expected_p;                // P制御
+    double i = currentDiviation * DELTA * expected_i;        // I制御(誤差の累積は0)
+    double d = (currentDiviation - preDeviation) * expected_d / DELTA;  // D制御(前回の誤差は0)
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
 
-    double integral = currentDiviation * DELTA; //誤差の累積
-    preDeviation += currentDiviation;           //前回の誤差の更新
+    double integral = currentDiviation * DELTA;  //誤差の累積
+    preDeviation += currentDiviation;            //前回の誤差の更新
     expected_p = 0.1;
     expected_i = 0.2;
     expected_d = 0.3;
-    actualPid.setPidGain(expected_p, expected_i, expected_d); // PIDゲインの更新
+    actualPid.setPidGain(expected_p, expected_i, expected_d);  // PIDゲインの更新
     currentValue = 100;
     currentDiviation = (targetValue - currentValue);
     integral += currentDiviation * DELTA;
@@ -189,4 +188,4 @@ namespace etrobocon2022_test
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
-} // namespace etrobocon2022_test
+}  // namespace etrobocon2022_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [X] コーディング規約に準じている
- [X] チケットの完了条件を満たしている

# 変更点
`Dockerfile`を修正した。
具体的には、`sudo`コマンドのオプションも含めて削除するように変更した。

> **Note**  
> `sudo`コマンドを削除する理由としては、Dockerコンテナ中のデフォルトユーザ(root)では`sudo`コマンドを使用できないためである。

## エラーの原因
ビルドチェックでエラーが発生するようになった期間における、etrobo環境のコミット履歴を確認したところ以下のような変更があった。

以下、変更前
```
        sudo gem install shell -E
```

以下、変更後
```
        sudo -E gem install shell
```

このプルリクエストで修正する前のDockerfileでは、`sudo`コマンドのみを削除しオプションは削除しないようになっていた。
そのため、Rubyのパッケージをインストールすることができず、エラーが発生したと考えられる。

参考：https://github.com/ETrobocon/etrobo/commit/033e6e0588c36fc372c4540b72385e08a0513011

# 動作テスト
以下、実行結果
- https://github.com/KatLab-MiyazakiUniv/etrobocon2022/actions/runs/2547836057
