### PR TITLE
close #26 ライトレースエリアを攻略する

### DIFF
--- a/module/API/Controller.cpp
+++ b/module/API/Controller.cpp
@@ -17,39 +17,39 @@ int Controller::limitPwmValue(const int value)
   return value;
 }
 
-// PWM値を右モータにセット
+// 右モータにPWM値をセット
 void Controller::setRightMotorPwm(const int pwm)
 {
   rightWheel.setPWM(limitPwmValue(pwm));
 }
 
-// PWM値を左モータにセット
+// 左モータにPWM値をセット
 void Controller::setLeftMotorPwm(const int pwm)
 {
   leftWheel.setPWM(limitPwmValue(pwm));
 }
 
-//タイヤのモータを停止する
+// タイヤのモータを停止する
 void Controller::stopMotor()
 {
   leftWheel.stop();
   rightWheel.stop();
 }
 
-// PWM値をアームのモータにセット
+// アームのモータにPWM値をセット
 void Controller::setArmMotorPwm(const int pwm)
 {
   armMotor.setPWM(limitPwmValue(pwm));
 }
 
-//アームのモータを停止
+// アームのモータを停止する
 void Controller::stopArmMotor()
 {
   armMotor.stop();
 }
 
-//スリープ
-void Controller::sleep(int milliSec)
+// 自タスクスリープ（デフォルトは10ミリ秒）
+void Controller::sleep(int microSec)
 {
-  clock.sleep(milliSec);
+  clock.sleep(microSec);
 }

--- a/module/API/Controller.h
+++ b/module/API/Controller.h
@@ -18,7 +18,7 @@ class Controller {
   Controller();
 
   /**
-   * モータにPWM値をセット
+   * タイヤのモータにPWM値をセット
    * @param pwm PWM値
    */
   void setRightMotorPwm(const int pwm);
@@ -30,7 +30,7 @@ class Controller {
   void stopMotor();
 
   /**
-   * アームにPWM値をセット
+   * アームのモータにPWM値をセット
    * @param pwm PWM値
    */
   void setArmMotorPwm(const int pwm);
@@ -41,10 +41,10 @@ class Controller {
   void stopArmMotor();
 
   /**
-   * 自タスクスリープ
-   * @param milliSec スリープ時間(ミリ秒)
+   * 自タスクスリープ（デフォルトは10ミリ秒）
+   * @param milliSec スリープ時間(マイクロ秒)
    */
-  void sleep(int milliSec = 10);
+  void sleep(int microSec = 10000);
 
   // /**
   //  * シミュレータへ競技の終了を通知する

--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -6,12 +6,7 @@
 
 #include "Measurer.h"
 
-Measurer::Measurer()
-  : colorSensor(PORT_3),
-    leftWheel(PORT_C),
-    rightWheel(PORT_B),
-    armMotor(PORT_A),
-    touchSensor(PORT_1)
+Measurer::Measurer() : colorSensor(PORT_2), leftWheel(PORT_C), rightWheel(PORT_B), armMotor(PORT_A)
 {
 }
 
@@ -45,10 +40,4 @@ int Measurer::getRightCount()
 int Measurer::getArmMotorCount()
 {
   return armMotor.getCount();
-}
-
-//タッチセンサの状態取得
-bool Measurer::isPressed()
-{
-  return touchSensor.isPressed();
 }

--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -13,10 +13,14 @@ Measurer::Measurer() : colorSensor(PORT_2), leftWheel(PORT_C), rightWheel(PORT_B
 //明るさを取得
 int Measurer::getBrightness()
 {
-  return colorSensor.getBrightness();
+  // RGBモードと光センサモードを併用すると動作が悪くなるためRGBモードで取得する
+  // 参考: https://qiita.com/kawanon868/items/5d52eb291c3f71af0419
+  rgb_raw_t rgb = getRawColor();
+  int brightness = std::max({ rgb.r, rgb.g, rgb.b }) / 2.55;
+  return brightness;
 }
 
-// RGB値を返す
+// RGB値を取得
 rgb_raw_t Measurer::getRawColor()
 {
   rgb_raw_t rgb;

--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -10,13 +10,14 @@ Measurer::Measurer() : colorSensor(PORT_2), leftWheel(PORT_C), rightWheel(PORT_B
 {
 }
 
-//明るさを取得
+// 明るさを取得
+// 参考: https://tomari.org/main/java/color/ccal.html
 int Measurer::getBrightness()
 {
   // RGBモードと光センサモードを併用すると動作が悪くなるためRGBモードで取得する
   // 参考: https://qiita.com/kawanon868/items/5d52eb291c3f71af0419
   rgb_raw_t rgb = getRawColor();
-  int brightness = std::max({ rgb.r, rgb.g, rgb.b }) / 2.55;
+  int brightness = std::max({ rgb.r, rgb.g, rgb.b }) * 100 / 255;  // 明度を取得して0-100に正規化
   return brightness;
 }
 

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -10,7 +10,6 @@
 #include "ev3api.h"
 #include "ColorSensor.h"
 #include "Motor.h"
-#include "TouchSensor.h"
 
 class Measurer {
  public:
@@ -60,7 +59,6 @@ class Measurer {
   ev3api::Motor leftWheel;
   ev3api::Motor rightWheel;
   ev3api::Motor armMotor;
-  ev3api::TouchSensor touchSensor;
 };
 
 #endif

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -7,6 +7,7 @@
 #ifndef MEASURER_H
 #define MEASURER_H
 
+#include <algorithm>
 #include "ev3api.h"
 #include "ColorSensor.h"
 #include "Motor.h"
@@ -47,12 +48,6 @@ class Measurer {
    * @return アームモータ角位置[deg]
    */
   int getArmMotorCount();
-
-  /**
-   * タッチセンサ状態取得
-   * @return true:押されている状態, false:押されていない状態
-   */
-  bool isPressed();
 
  private:
   ev3api::ColorSensor colorSensor;

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -1,8 +1,16 @@
 /**
  * @file EtRobocon2022.cpp
  * @brief 全体を制御するクラス
- * @author Takahiro55555
+ * @author Takahiro55555 mutotaka0426
  */
 
 #include "EtRobocon2022.h"
-void EtRobocon2022::start() {}
+#include "LineTraceArea.h"
+#include "LineTracer.h"
+#include "Pid.h"
+#include <stdio.h>
+void EtRobocon2022::start()
+{
+  bool isLeftCourse = true;  // true:Lコース, false:Rコース
+  LineTraceArea::runLineTraceArea(isLeftCourse);
+}

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -5,10 +5,7 @@
  */
 
 #include "EtRobocon2022.h"
-#include "LineTraceArea.h"
-#include "LineTracer.h"
-#include "Pid.h"
-#include <stdio.h>
+
 void EtRobocon2022::start()
 {
   bool isLeftCourse = true;  // true:Lコース, false:Rコース

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -8,6 +8,8 @@
 
 void EtRobocon2022::start()
 {
-  bool isLeftCourse = true;  // true:Lコース, false:Rコース
-  LineTraceArea::runLineTraceArea(isLeftCourse);
+  bool isLeftCourse = true;             // true:Lコース, false:Rコース
+  int targetBrightness = (93 - 3) / 2;  // 目標輝度
+
+  LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
 }

--- a/module/EtRobocon2022.h
+++ b/module/EtRobocon2022.h
@@ -6,6 +6,9 @@
 
 #ifndef ETROBOCON2022_H
 #define ETROBOCON2022_H
+
+#include "LineTraceArea.h"
+
 class EtRobocon2022 {
  public:
   static void start();

--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file LineTraceArea.cpp
+ * @brief ライントレースエリアを攻略するクラス
+ * @author mutotaka0426
+ */
+
+#include "LineTraceArea.h"
+#include "Controller.h"  // テスト用に書いたやつだから消し忘れるなよ
+using namespace std;
+
+// Lコースの情報を初期化する
+const array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::LEFT_COURSE_INFO
+    = { SectionParam{ 1070 + 30, 45, 50, PidGain(0.2, 0.8, 0.1) },
+        SectionParam{ 212 + 120, 45, 50, PidGain(1.2, 1.0, 1.0) },
+        SectionParam{ 1830, 45, 50, PidGain(1.0, 1.0, 1.0) },
+        SectionParam{ 190 + 120, 45, 50, PidGain(1.2, 1.0, 1.0) },
+        SectionParam{ 1100, 45, 50, PidGain(1.0, 0.8, 0.8) },
+        SectionParam{ 485 + 250, 45, 50, PidGain(1.2, 0.8, 0.8) } };
+
+// Rコースの情報を初期化する
+const array<SectionParam, LineTraceArea::RIGHT_SECTION_SIZE> LineTraceArea::RIGHT_COURSE_INFO
+    = { SectionParam{ 1070 + 30, 45, 50, PidGain(0.2, 0.8, 0.1) },
+        SectionParam{ 212 + 120, 45, 50, PidGain(1.2, 1.0, 1.0) },
+        SectionParam{ 1830, 45, 50, PidGain(1.0, 1.0, 1.0) },
+        SectionParam{ 190 + 120, 45, 50, PidGain(1.2, 1.0, 1.0) },
+        SectionParam{ 1100, 45, 50, PidGain(1.0, 0.8, 0.8) },
+        SectionParam{ 485 + 250, 45, 50, PidGain(1.2, 0.8, 0.8) } };
+
+void LineTraceArea::runLineTraceArea(const bool isLeftCourse)
+{
+  const SectionParam* param;
+  bool isLeftEdge;  // true:左エッジ, false:右エッジ
+
+  // Lコースの場合
+  param = LEFT_COURSE_INFO.begin();
+  // エッジをセット
+  isLeftEdge = isLeftCourse;
+  // LineTracerにエッジを与えてインスタンス化する
+  LineTracer lineTracer(isLeftEdge);
+
+  Controller controller;  // テスト用に書いたやつだから消し忘れるなよ
+
+  // LRに応じて各区間を順番に走らせる
+  for(int i = 0; i < LEFT_SECTION_SIZE; i++) {
+    // for(int i = 0; i < 4; i++) {
+    SectionParam section = param[i];
+    // Linetracerクラスのrun関数に区間の情報を渡して走行させる
+    lineTracer.run(section.distance, section.targetBrightness, section.pwm, section.pidGain);
+  }
+
+  // 緑までライントレース
+  lineTracer.runToColor(COLOR::GREEN, 45, 50, PidGain{ 1.0, 1.0, 1.0 });
+}
+

--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "LineTraceArea.h"
-#include "Controller.h"  // テスト用に書いたやつだから消し忘れるなよ
 using namespace std;
 
 // Lコースの情報を初期化する
@@ -38,11 +37,8 @@ void LineTraceArea::runLineTraceArea(const bool isLeftCourse)
   // LineTracerにエッジを与えてインスタンス化する
   LineTracer lineTracer(isLeftEdge);
 
-  Controller controller;  // テスト用に書いたやつだから消し忘れるなよ
-
   // LRに応じて各区間を順番に走らせる
   for(int i = 0; i < LEFT_SECTION_SIZE; i++) {
-    // for(int i = 0; i < 4; i++) {
     SectionParam section = param[i];
     // Linetracerクラスのrun関数に区間の情報を渡して走行させる
     lineTracer.run(section.distance, section.targetBrightness, section.pwm, section.pidGain);

--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -51,4 +51,3 @@ void LineTraceArea::runLineTraceArea(const bool isLeftCourse)
   // 緑までライントレース
   lineTracer.runToColor(COLOR::GREEN, 45, 50, PidGain{ 1.0, 1.0, 1.0 });
 }
-

--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -7,43 +7,58 @@
 #include "LineTraceArea.h"
 using namespace std;
 
-// Lコースの情報を初期化する
-const array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::LEFT_COURSE_INFO
-    = { SectionParam{ 1070 + 30, 45, 50, PidGain(0.2, 0.8, 0.1) },
-        SectionParam{ 212 + 120, 45, 50, PidGain(1.2, 1.0, 1.0) },
-        SectionParam{ 1830, 45, 50, PidGain(1.0, 1.0, 1.0) },
-        SectionParam{ 190 + 120, 45, 50, PidGain(1.2, 1.0, 1.0) },
-        SectionParam{ 1100, 45, 50, PidGain(1.0, 0.8, 0.8) },
-        SectionParam{ 485 + 250, 45, 50, PidGain(1.2, 0.8, 0.8) } };
+const array<double, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::LEFT_SECTION_DISTANCE
+    = { 1070, 212, 1830, 190, 1100, 485 };
 
-// Rコースの情報を初期化する
-const array<SectionParam, LineTraceArea::RIGHT_SECTION_SIZE> LineTraceArea::RIGHT_COURSE_INFO
-    = { SectionParam{ 1070 + 30, 45, 50, PidGain(0.2, 0.8, 0.1) },
-        SectionParam{ 212 + 120, 45, 50, PidGain(1.2, 1.0, 1.0) },
-        SectionParam{ 1830, 45, 50, PidGain(1.0, 1.0, 1.0) },
-        SectionParam{ 190 + 120, 45, 50, PidGain(1.2, 1.0, 1.0) },
-        SectionParam{ 1100, 45, 50, PidGain(1.0, 0.8, 0.8) },
-        SectionParam{ 485 + 250, 45, 50, PidGain(1.2, 0.8, 0.8) } };
+const array<double, LineTraceArea::RIGHT_SECTION_SIZE> LineTraceArea::RIGHT_SECTION_DISTANCE
+    = { 1070, 212, 1830, 190, 1100, 485 };
 
-void LineTraceArea::runLineTraceArea(const bool isLeftCourse)
+// Lコースのパラメータを初期化する（調整距離, PWM値, PIDゲイン）
+const array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE + 1> LineTraceArea::LEFT_COURSE_INFO = {
+  SectionParam{ 30, 50, PidGain(0.2, 0.8, 0.1) }, SectionParam{ 120, 50, PidGain(1.2, 1.0, 1.0) },
+  SectionParam{ 0, 50, PidGain(1.0, 1.0, 1.0) },  SectionParam{ 120, 50, PidGain(1.2, 1.0, 1.0) },
+  SectionParam{ 0, 50, PidGain(1.0, 0.8, 0.8) },  SectionParam{ 250, 50, PidGain(1.2, 0.8, 0.8) },
+  SectionParam{ 0, 50, PidGain(1.0, 1.0, 1.0) }
+};
+
+// Rコースのパラメータを初期化する（調整距離, PWM値, PIDゲイン）
+const array<SectionParam, LineTraceArea::RIGHT_SECTION_SIZE + 1> LineTraceArea::RIGHT_COURSE_INFO
+    = { SectionParam{ 30, 50, PidGain(0.2, 0.8, 0.1) },
+        SectionParam{ 120, 50, PidGain(1.2, 1.0, 1.0) },
+        SectionParam{ 0, 50, PidGain(1.0, 1.0, 1.0) },
+        SectionParam{ 120, 50, PidGain(1.2, 1.0, 1.0) },
+        SectionParam{ 0, 50, PidGain(1.0, 0.8, 0.8) },
+        SectionParam{ 250, 50, PidGain(1.2, 0.8, 0.8) },
+        SectionParam{ 0, 50, PidGain(1.0, 1.0, 1.0) } };
+
+void LineTraceArea::runLineTraceArea(const bool isLeftCourse, const int targetBrightness)
 {
-  const SectionParam* param;
-  bool isLeftEdge;  // true:左エッジ, false:右エッジ
+  int size;                   // 区間の数
+  const double* DISTANCE;     // 各区間の距離
+  const SectionParam* PARAM;  // ファイルから受け取ったパラメータ
+  bool isLeftEdge;            // true:左エッジ, false:右エッジ
 
-  // Lコースの場合
-  param = LEFT_COURSE_INFO.begin();
+  if(isLeftCourse) {  // Lコースの場合
+    size = LEFT_SECTION_SIZE;
+    DISTANCE = LEFT_SECTION_DISTANCE.begin();
+    PARAM = LEFT_COURSE_INFO.begin();
+  } else {  // Rコースの場合
+    size = RIGHT_SECTION_SIZE;
+    DISTANCE = RIGHT_SECTION_DISTANCE.begin();
+    PARAM = RIGHT_COURSE_INFO.begin();
+  }
+
   // エッジをセット
   isLeftEdge = isLeftCourse;
   // LineTracerにエッジを与えてインスタンス化する
   LineTracer lineTracer(isLeftEdge);
 
   // LRに応じて各区間を順番に走らせる
-  for(int i = 0; i < LEFT_SECTION_SIZE; i++) {
-    SectionParam section = param[i];
-    // Linetracerクラスのrun関数に区間の情報を渡して走行させる
-    lineTracer.run(section.distance, section.targetBrightness, section.pwm, section.pidGain);
+  for(int i = 0; i < size; i++) {
+    // Linetracer::runに区間の情報を渡して走行させる
+    lineTracer.run(DISTANCE[i] + PARAM[i].tweak, targetBrightness, PARAM[i].pwm, PARAM[i].pidGain);
   }
 
   // 緑までライントレース
-  lineTracer.runToColor(COLOR::GREEN, 45, 50, PidGain{ 1.0, 1.0, 1.0 });
+  lineTracer.runToColor(COLOR::GREEN, targetBrightness, PARAM[size].pwm, PARAM[size].pidGain);
 }

--- a/module/LineTraceArea.h
+++ b/module/LineTraceArea.h
@@ -10,28 +10,33 @@
 #include <array>
 #include "LineTracer.h"
 
-//区間の情報を保持する構造体
+// 区間制御のパラメータを保持する構造体
 struct SectionParam {
-  double distance;       //走行距離
-  int targetBrightness;  //目標輝度
-  int pwm;               // PWM値
-  PidGain pidGain;       // PIDゲイン
+  double tweak;     // 調整距離
+  int pwm;          // PWM値
+  PidGain pidGain;  // PIDゲイン
 };
 
 class LineTraceArea {
  public:
   /**
-   * @fn static void runLineTraceArea();
    * @brief ライントレースエリアを走行する
    * @param isLeftCourse コースのLR判定(true:Lコース, false:Rコース)
+   * @param targetBrightness 目標輝度
    */
-  static void runLineTraceArea(const bool isLeftCourse);
+  static void runLineTraceArea(const bool isLeftCourse, const int targetBrightness);
 
  private:
-  static const int LEFT_SECTION_SIZE = 6;   // Lコースの区間の数
-  static const int RIGHT_SECTION_SIZE = 6;  // Rコースの区間の数
-  static const std::array<SectionParam, LEFT_SECTION_SIZE> LEFT_COURSE_INFO;  // Lコースの情報
-  static const std::array<SectionParam, RIGHT_SECTION_SIZE> RIGHT_COURSE_INFO;  // Rコースの情報
+  static constexpr int LEFT_SECTION_SIZE = 6;   // Lコースの区間の数
+  static constexpr int RIGHT_SECTION_SIZE = 6;  // Rコースの区間の数
+  // Lコースの各区間の距離
+  static const std::array<double, LEFT_SECTION_SIZE> LEFT_SECTION_DISTANCE;
+  // Rコースの各区間の距離
+  static const std::array<double, LEFT_SECTION_SIZE> RIGHT_SECTION_DISTANCE;
+
+  // 以下の2つの定数はファイル読み込みに置き換える（最後の要素は緑までライントレースのパラメータ）
+  static const std::array<SectionParam, LEFT_SECTION_SIZE + 1> LEFT_COURSE_INFO;  // Lコースの情報
+  static const std::array<SectionParam, RIGHT_SECTION_SIZE + 1> RIGHT_COURSE_INFO;  // Rコースの情報
 
   LineTraceArea();  // インスタンス化を禁止する
 };

--- a/module/LineTraceArea.h
+++ b/module/LineTraceArea.h
@@ -1,0 +1,39 @@
+/**
+ * @file LineTraceArea.h
+ * @brief ライントレースエリアを攻略するクラス
+ * @author mutotaka0426
+ */
+
+#ifndef LINE_TRACE_AREA_H
+#define LINE_TRACE_AREA_H
+
+#include <array>
+#include "LineTracer.h"
+
+//区間の情報を保持する構造体
+struct SectionParam {
+  double distance;       //走行距離
+  int targetBrightness;  //目標輝度
+  int pwm;               // PWM値
+  PidGain pidGain;       // PIDゲイン
+};
+
+class LineTraceArea {
+ public:
+  /**
+   * @fn static void runLineTraceArea();
+   * @brief ライントレースエリアを走行する
+   * @param isLeftCourse コースのLR判定(true:Lコース, false:Rコース)
+   */
+  static void runLineTraceArea(const bool isLeftCourse);
+
+ private:
+  static const int LEFT_SECTION_SIZE = 6;   // Lコースの区間の数
+  static const int RIGHT_SECTION_SIZE = 6;  // Rコースの区間の数
+  static const std::array<SectionParam, LEFT_SECTION_SIZE> LEFT_COURSE_INFO;  // Lコースの情報
+  static const std::array<SectionParam, RIGHT_SECTION_SIZE> RIGHT_COURSE_INFO;  // Rコースの情報
+
+  LineTraceArea();  // インスタンス化を禁止する
+};
+
+#endif

--- a/module/Motion/ColorJudge.cpp
+++ b/module/Motion/ColorJudge.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file ColorJudge.cpp
+ * @brief 色識別クラス
+ * @author mutotaka0426
+ */
+
+#include "ColorJudge.h"
+
+// RGBから色を判別する
+COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
+{
+  rgb_raw_t rgb;
+  Hsv hsv;
+  int min;
+
+  // 環境光による値の偏りを軽減する
+  // 事前に測った白が(255,255,255)となるように、RGB値を正規化する
+  rgb.r = (_rgb.r < MAX_RGB.r) ? std::max((_rgb.r - MIN_RGB.r), 0) * 255 / (MAX_RGB.r - MIN_RGB.r)
+                               : 255;
+  rgb.g = (_rgb.g < MAX_RGB.g) ? std::max((_rgb.g - MIN_RGB.g), 0) * 255 / (MAX_RGB.g - MIN_RGB.g)
+                               : 255;
+  rgb.b = (_rgb.b < MAX_RGB.b) ? std::max((_rgb.b - MIN_RGB.b), 0) * 255 / (MAX_RGB.b - MIN_RGB.b)
+                               : 255;
+
+  // HSV値に変換
+  hsv = convertRgbToHsv(rgb);
+
+  // RGBの中の最小値を取得
+  min = std::min({ rgb.r, rgb.g, rgb.b });
+
+  // 明度が極端に低ければ、黒を返す
+  if(hsv.value < BLACK_LIMIT_BORDER) return COLOR::BLACK;
+  // 明度が極端に高ければ、白を返す
+  if(min > WHITE_LIMIT_BORDER) return COLOR::WHITE;
+  // 彩度が低い場合
+  if(hsv.saturation < SATURATION_BORDER) {
+    // 明度が低ければ、黒を返す
+    if(hsv.value < BLACK_BORDER) return COLOR::BLACK;
+    // 明度が高ければ、白を返す
+    return COLOR::WHITE;
+  }
+
+  // 各色相の境界によって、色を判別する
+  if(hsv.hue < RED_BORDER) return COLOR::RED;
+  if(hsv.hue < YELLOW_BORDER) return COLOR::YELLOW;
+  if(hsv.hue < GREEN_BORDER) return COLOR::GREEN;
+  if(hsv.hue < BLUE_BORDER) return COLOR::BLUE;
+  return COLOR::RED;
+}
+
+// RGBをHSVに変換する
+// 参考: https://tomari.org/main/java/color/ccal.html
+Hsv ColorJudge::convertRgbToHsv(rgb_raw_t const& _rgb)
+{
+  Hsv hsv{ 0, 0, 0 };
+
+  // RGBの中の最大・最小値を求める
+  int max = std::max({ _rgb.r, _rgb.g, _rgb.b });
+  int min = std::min({ _rgb.r, _rgb.g, _rgb.b });
+
+  // maxが0の場合、黒を返す
+  if(max == 0) {
+    return hsv;
+  }
+
+  // 色相
+  if(max == min) {
+    hsv.hue = 0;
+  } else if(_rgb.r == max) {
+    hsv.hue = 60 * (_rgb.g - _rgb.b) / (max - min);
+  } else if(_rgb.g == max) {
+    hsv.hue = 60 * (_rgb.b - _rgb.r) / (max - min) + 120;
+  } else if(_rgb.b == max) {
+    hsv.hue = 60 * (_rgb.r - _rgb.g) / (max - min) + 240;
+  }
+  // マイナスの場合の補完
+  hsv.hue = (hsv.hue + 360) % 360;
+
+  // 彩度
+  hsv.saturation = 100 * (max - min) / max;
+
+  // 明度
+  hsv.value = max;
+
+  return hsv;
+}

--- a/module/Motion/ColorJudge.h
+++ b/module/Motion/ColorJudge.h
@@ -1,0 +1,61 @@
+/**
+ * @file ColorJudge.h
+ * @brief 色識別クラス
+ * @author mutotaka0426
+ */
+
+#ifndef COLOR_JUDGE_H
+#define COLOR_JUDGE_H
+
+#include <algorithm>
+#include "Measurer.h"
+
+enum class COLOR : int {
+  NONE = 0,
+  BLACK = 1,
+  WHITE = 2,
+  BLUE = 3,
+  GREEN = 4,
+  YELLOW = 5,
+  RED = 6,
+};
+
+struct Hsv {
+  int hue;         // 色相(0-360)
+  int saturation;  // 彩度(0-100)
+  int value;       // 明度(0-255)
+};
+
+class ColorJudge {
+ public:
+  /**
+   * 与えられたRGB値から、何色かを返す
+   * @param rgb RGB
+   * @return 色
+   */
+  static COLOR getColor(rgb_raw_t const& rgb);
+
+ private:
+  static constexpr int SATURATION_BORDER = 15;  // 無彩色かどうかの彩度の境界
+
+  static constexpr int BLACK_LIMIT_BORDER = 80;            // 黒の明度の境界
+  static constexpr int WHITE_LIMIT_BORDER = 140;           // 白の明度の境界
+  static constexpr int BLACK_BORDER = 110;                 // 無彩色の黒の明度の境界
+  static constexpr int RED_BORDER = 30;                    // 赤の色相の境界
+  static constexpr int YELLOW_BORDER = 75;                 // 黄の色相の境界
+  static constexpr int GREEN_BORDER = 170;                 // 緑の色相の境界
+  static constexpr int BLUE_BORDER = 300;                  // 青の色相の境界
+  static constexpr rgb_raw_t MAX_RGB = { 154, 143, 196 };  //コースが白の時（最大）のRGB値
+  static constexpr rgb_raw_t MIN_RGB = { 4, 5, 8 };  //コースが黒の時（最小）のRGB値
+
+  ColorJudge();  // インスタンス化を禁止する
+
+  /**
+   * RGBをHSVに変換する
+   * @param rgb RGB
+   * @return hsv HSV
+   */
+  static Hsv convertRgbToHsv(rgb_raw_t const& rgb);
+};
+
+#endif

--- a/module/Motion/LineTracer.cpp
+++ b/module/Motion/LineTracer.cpp
@@ -26,7 +26,7 @@ void LineTracer::run(double targetDistance, int targetBrightness, int pwm, const
   }
 
   //左右で符号を変える
-  sign = (isLeftEdge) ? -1 : 1;
+  sign = isLeftEdge ? -1 : 1;
 
   // 初期値を格納
   initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
@@ -67,7 +67,7 @@ void LineTracer::runToColor(COLOR targetColor, int targetBrightness, int pwm, co
   }
 
   //左右で符号を変える
-  sign = (isLeftEdge) ? -1 : 1;
+  sign = isLeftEdge ? -1 : 1;
 
   //指定された色をJUDGE_COUNT回連続で取得するまで繰り返す
   while(colorCount < JUDGE_COUNT) {

--- a/module/Motion/LineTracer.cpp
+++ b/module/Motion/LineTracer.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file LineTracer.cpp
+ * @brief ライントレースをするクラス
+ * @author mutotaka0426
+ */
+
+#include "LineTracer.h"
+using namespace std;
+
+LineTracer::LineTracer(bool _isLeftEdge) : isLeftEdge(_isLeftEdge) {}
+
+void LineTracer::run(double targetDistance, int targetBrightness, int pwm, const PidGain& gain)
+{
+  double initialDistance = 0;
+  double currentDistance = 0;
+  int currentPid = 0;
+  int sign = 0;
+  Pid pid(gain.kp, gain.ki, gain.kd, targetBrightness);
+
+  // pwm値が0の場合はwarningを出して終了する
+  if(pwm == 0) {
+    printf("\x1b[36m"); /* 文字色をシアンに */
+    printf("warning: The pwm value passed to LineTracer::run is 0\n");
+    printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
+    return;
+  }
+
+  //左右で符号を変える
+  sign = (isLeftEdge) ? -1 : 1;
+
+  // 初期値を格納
+  initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+  currentDistance = initialDistance;
+
+  //走行距離が目標距離に到達するまで繰り返す
+  while(abs(currentDistance - initialDistance) < targetDistance) {
+    currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+    // PID計算
+    currentPid = pid.calculatePid(measurer.getBrightness()) * sign;
+
+    //モータのPWM値をセット（0を超えないようにセット）
+    int rightPwm = pwm > 0 ? max(pwm - (int)currentPid, 0) : min(pwm - (int)currentPid, 0);
+    int leftPwm = pwm > 0 ? max(pwm + (int)currentPid, 0) : min(pwm + (int)currentPid, 0);
+    controller.setRightMotorPwm(rightPwm);
+    controller.setLeftMotorPwm(leftPwm);
+    // 10ミリ秒待機
+    controller.sleep();
+  }
+  //モータの停止
+  controller.stopMotor();
+}
+
+void LineTracer::runToColor(COLOR targetColor, int targetBrightness, int pwm, const PidGain& gain)
+{
+  int currentPid = 0;
+  int sign = 0;
+  Pid pid(gain.kp, gain.ki, gain.kd, targetBrightness);
+  COLOR currentColor = COLOR::NONE;
+  int colorCount = 0;
+
+  // pwm値が0の場合はwarningを出して終了する
+  if(pwm == 0) {
+    printf("\x1b[36m"); /* 文字色をシアンに */
+    printf("warning: The pwm value passed to LineTracer::runToColor is 0\n");
+    printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
+    return;
+  }
+
+  //左右で符号を変える
+  sign = (isLeftEdge) ? -1 : 1;
+
+  //指定された色を取得するまで繰り返す
+  while(colorCount < 3) {
+    currentColor = ColorJudge::getColor(measurer.getRawColor());
+    if(currentColor == targetColor) {
+      colorCount++;
+    } else {
+      colorCount = 0;
+    }
+    // PID計算
+    currentPid = pid.calculatePid(measurer.getBrightness()) * sign;
+
+    //モータのPWM値をセット（0を超えないようにセット）
+    int rightPwm = pwm > 0 ? max(pwm - (int)currentPid, 0) : min(pwm - (int)currentPid, 0);
+    int leftPwm = pwm > 0 ? max(pwm + (int)currentPid, 0) : min(pwm + (int)currentPid, 0);
+    controller.setRightMotorPwm(rightPwm);
+    controller.setLeftMotorPwm(leftPwm);
+    // 10ミリ秒待機
+    controller.sleep();
+  }
+  //モータの停止
+  controller.stopMotor();
+}
+
+bool LineTracer::getIsLeftEdge()
+{
+  return isLeftEdge;
+}
+
+void LineTracer::setIsLeftEdge(bool _isLeftEdge)
+{
+  isLeftEdge = _isLeftEdge;
+}
+
+void LineTracer::toggleEdge()
+{
+  isLeftEdge = !isLeftEdge;
+}

--- a/module/Motion/LineTracer.cpp
+++ b/module/Motion/LineTracer.cpp
@@ -69,7 +69,7 @@ void LineTracer::runToColor(COLOR targetColor, int targetBrightness, int pwm, co
   //左右で符号を変える
   sign = (isLeftEdge) ? -1 : 1;
 
-  //指定された色を回連続で取得するまで繰り返す
+  //指定された色をJUDGE_COUNT回連続で取得するまで繰り返す
   while(colorCount < JUDGE_COUNT) {
     currentColor = ColorJudge::getColor(measurer.getRawColor());
     if(currentColor == targetColor) {

--- a/module/Motion/LineTracer.cpp
+++ b/module/Motion/LineTracer.cpp
@@ -69,8 +69,8 @@ void LineTracer::runToColor(COLOR targetColor, int targetBrightness, int pwm, co
   //左右で符号を変える
   sign = (isLeftEdge) ? -1 : 1;
 
-  //指定された色を取得するまで繰り返す
-  while(colorCount < 3) {
+  //指定された色を回連続で取得するまで繰り返す
+  while(colorCount < JUDGE_COUNT) {
     currentColor = ColorJudge::getColor(measurer.getRawColor());
     if(currentColor == targetColor) {
       colorCount++;

--- a/module/Motion/LineTracer.h
+++ b/module/Motion/LineTracer.h
@@ -62,6 +62,7 @@ class LineTracer {
   bool isLeftEdge;
   Measurer measurer;
   Controller controller;
+  static constexpr int JUDGE_COUNT = 3;
 };
 
 #endif

--- a/module/Motion/LineTracer.h
+++ b/module/Motion/LineTracer.h
@@ -1,0 +1,67 @@
+/**
+ * @file LineTracer.h
+ * @brief ライントレースをするクラス
+ * @author mutotaka0426
+ */
+
+#ifndef LINE_TRACER_H
+#define LINE_TRACER_H
+
+#include <stdio.h>
+#include <algorithm>
+#include "Pid.h"
+#include "Mileage.h"
+#include "ColorJudge.h"
+#include "Controller.h"
+#include "Measurer.h"
+
+class LineTracer {
+ public:
+  /**
+   * コンストラクタ
+   * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
+   */
+  LineTracer(bool _isLeftEdge);
+
+  /**
+   * 指定された距離の間ライントレースをする
+   * @param targetDistance 目標距離
+   * @param targetBrightness 目標輝度
+   * @param pwm PWM値
+   * @param gain PIDゲイン
+   */
+  void run(double targetDistance, int targetBrightness, int pwm, const PidGain& gain);
+
+  /**
+   * 指定された色を判定するまでライントレースをする
+   * @param targetColor 指定色
+   * @param targetBrightness 目標輝度
+   * @param pwm PWM値
+   * @param gain PIDゲイン
+   */
+  void runToColor(COLOR targetColor, int targetBrightness, int pwm, const PidGain& gain);
+
+  /**
+   * エッジのゲッター
+   * @return true: 左エッジ, false: 右エッジ
+   */
+  bool getIsLeftEdge();
+
+  /**
+   * エッジのセッター
+   * @param _isLeftEdge true: 左エッジ, false: 右エッジ
+   */
+  void setIsLeftEdge(bool _isLeftEdge);
+
+  /**
+   * エッジを切り替える
+   */
+  void toggleEdge();
+
+ private:
+  bool isLeftEdge;
+  Measurer measurer;
+  Controller controller;
+};
+
+#endif

--- a/test/ColorJudgeTest.cpp
+++ b/test/ColorJudgeTest.cpp
@@ -1,0 +1,194 @@
+/**
+ * @file ColorJudgeTest.cpp
+ * @brief ColorJudgeクラスをテストする
+ * @author mutotaka0426
+ */
+
+#include "ColorJudge.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2022_test {
+  TEST(getColorTest, getColorTrueBlack)
+  {
+    rgb_raw_t rgb = { 0, 0, 0 };
+    COLOR expected = COLOR::BLACK;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightBlack)
+  {
+    rgb_raw_t rgb = { 39, 39, 58 };
+    COLOR expected = COLOR::BLACK;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkBlack)
+  {
+    rgb_raw_t rgb = { 4, 5, 8 };
+    COLOR expected = COLOR::BLACK;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightRed)
+  {
+    rgb_raw_t rgb = { 119, 81, 109 };
+    COLOR expected = COLOR::RED;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkRed)
+  {
+    rgb_raw_t rgb = { 111, 19, 19 };
+    COLOR expected = COLOR::RED;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightRed2)
+  {
+    rgb_raw_t rgb = { 101, 76, 107 };
+    COLOR expected = COLOR::RED;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkRed2)
+  {
+    rgb_raw_t rgb = { 93, 16, 16 };
+    COLOR expected = COLOR::RED;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightYellow)
+  {
+    rgb_raw_t rgb = { 120, 108, 71 };
+    COLOR expected = COLOR::YELLOW;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkYellow)
+  {
+    rgb_raw_t rgb = { 120, 104, 8 };
+    COLOR expected = COLOR::YELLOW;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightYellow2)
+  {
+    rgb_raw_t rgb = { 104, 96, 71 };
+    COLOR expected = COLOR::YELLOW;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkYellow2)
+  {
+    rgb_raw_t rgb = { 104, 92, 8 };
+    COLOR expected = COLOR::YELLOW;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightGreen)
+  {
+    rgb_raw_t rgb = { 72, 100, 106 };
+    COLOR expected = COLOR::GREEN;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkGreen)
+  {
+    rgb_raw_t rgb = { 4, 75, 35 };
+    COLOR expected = COLOR::GREEN;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightGreen2)
+  {
+    rgb_raw_t rgb = { 85, 94, 124 };
+    COLOR expected = COLOR::GREEN;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkGreen2)
+  {
+    rgb_raw_t rgb = { 4, 64, 29 };
+    COLOR expected = COLOR::GREEN;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightBlue)
+  {
+    rgb_raw_t rgb = { 81, 92, 144 };
+    COLOR expected = COLOR::BLUE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkBlue)
+  {
+    rgb_raw_t rgb = { 4, 45, 112 };
+    COLOR expected = COLOR::BLUE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightBlue2)
+  {
+    rgb_raw_t rgb = { 83, 89, 137 };
+    COLOR expected = COLOR::BLUE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkBlue2)
+  {
+    rgb_raw_t rgb = { 4, 40, 103 };
+    COLOR expected = COLOR::BLUE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightWhite)
+  {
+    rgb_raw_t rgb = { 104, 101, 146 };
+    COLOR expected = COLOR::WHITE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkWhite)
+  {
+    rgb_raw_t rgb = { 92, 94, 141 };
+    COLOR expected = COLOR::WHITE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorMaxRgb)
+  {
+    rgb_raw_t rgb = { 112, 107, 152 };
+    COLOR expected = COLOR::WHITE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorFullRgb)
+  {
+    rgb_raw_t rgb = { 255, 255, 255 };
+    COLOR expected = COLOR::WHITE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+}  // namespace etrobocon2022_test

--- a/test/LineTraceAreaTest.cpp
+++ b/test/LineTraceAreaTest.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file LineTraceAreaTest.cpp
+ * @brief LineTracerAreaクラスのテスト
+ * @author mutotaka0426
+ */
+
+#include "LineTraceArea.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2022_test {
+
+  // Lコースで呼び出すだけのテスト
+  TEST(LineTraceAreaTest, runLeftCourse)
+  {
+    bool isLeftCourse = true;
+    int targetBrightness = 45;
+    LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
+  }
+
+  // Rコースで呼び出すだけのテスト
+  TEST(LineTraceAreaTest, runRightCourse)
+  {
+    bool isLeftCourse = false;
+    int targetBrightness = 45;
+    LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
+  }
+}  // namespace etrobocon2022_test

--- a/test/LineTracerTest.cpp
+++ b/test/LineTracerTest.cpp
@@ -1,0 +1,151 @@
+/**
+ * @file LineTracerTest.cpp
+ * @brief LineTracerクラスのテスト
+ * @author mutotaka0426
+ */
+
+#include "LineTracer.h"
+#include <math.h>
+#include <gtest/gtest.h>
+
+namespace etrobocon2022_test {
+
+  TEST(LineTracerTest, runLeftEdge)
+  {
+    Measurer measurer;
+    bool isLeftEdge = true;
+    LineTracer lineTracer(isLeftEdge);
+    double targetDistance = 1000;
+    double targetBrightness = 45;
+    int pwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    // ライントレース前のモータ回転数
+    int initialRightCount = measurer.getRightCount();
+    int initialLeftCount = measurer.getLeftCount();
+
+    // 直線を想定してライントレースを実行
+    lineTracer.run(targetDistance, targetBrightness, pwm, gain);
+
+    int rightCount = measurer.getRightCount() - initialRightCount;
+    int leftCount = measurer.getLeftCount() - initialLeftCount;
+    int actual = std::abs(rightCount - leftCount);  // 両輪の回転差
+    int expectedError = 50;                         // 両輪の回転の予測誤差（deg）
+
+    // ライントレース後の両輪の回転差が予測誤差以下である．
+    EXPECT_GE(expectedError, actual);
+  }
+
+  TEST(LineTracerTest, runRightEdge)
+  {
+    Measurer measurer;
+    bool isLeftEdge = false;
+    LineTracer lineTracer(isLeftEdge);
+    double targetDistance = 1000;
+    double targetBrightness = 45;
+    int pwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    // ライントレース前のモータ回転数
+    int initialRightCount = measurer.getRightCount();
+    int initialLeftCount = measurer.getLeftCount();
+
+    // 直線を想定してライントレースを実行
+    lineTracer.run(targetDistance, targetBrightness, pwm, gain);
+
+    int rightCount = measurer.getRightCount() - initialRightCount;
+    int leftCount = measurer.getLeftCount() - initialLeftCount;
+    int actual = std::abs(rightCount - leftCount);  // 両輪の回転差
+    int expectedError = 50;                         // 両輪の回転の予測誤差（deg）
+
+    // ライントレース後の両輪の回転差が予測誤差以下である．
+    EXPECT_GE(expectedError, actual);
+  }
+
+  TEST(LineTracerTest, runZeroPWM)
+  {
+    Measurer measurer;
+    bool isLeftEdge = true;
+    LineTracer lineTracer(isLeftEdge);
+    double targetDistance = 1000;
+    double targetBrightness = 45;
+    int pwm = 0;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    // ライントレース前のモータ回転数
+    int initialRightCount = measurer.getRightCount();
+    int initialLeftCount = measurer.getLeftCount();
+
+    // 直線を想定してライントレースを実行
+    lineTracer.run(targetDistance, targetBrightness, pwm, gain);
+
+    int rightCount = measurer.getRightCount() - initialRightCount;
+    int leftCount = measurer.getLeftCount() - initialLeftCount;
+    int actual = std::abs(rightCount - leftCount);  // 両輪の回転差
+    int expectedError = 0;                          // 両輪の回転の予測誤差（deg）
+
+    // ライントレース後の両輪の回転差が予測誤差以下である．
+    EXPECT_EQ(expectedError, actual);
+  }
+
+  TEST(LineTracerTest, runBack)
+  {
+    Measurer measurer;
+    bool isLeftEdge = true;
+    LineTracer lineTracer(isLeftEdge);
+    double targetDistance = 1000;
+    double targetBrightness = 45;
+    int pwm = -100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    // ライントレース前のモータ回転数
+    int initialRightCount = measurer.getRightCount();
+    int initialLeftCount = measurer.getLeftCount();
+
+    // 直線を想定してライントレースを実行
+    lineTracer.run(targetDistance, targetBrightness, pwm, gain);
+
+    int rightCount = measurer.getRightCount() - initialRightCount;
+    int leftCount = measurer.getLeftCount() - initialLeftCount;
+    int actual = std::abs(rightCount - leftCount);  // 両輪の回転差
+    int expectedError = 50;                         // 両輪の回転の予測誤差（deg）
+
+    // ライントレース後の両輪の回転差が予測誤差以下である．
+    EXPECT_GE(expectedError, actual);
+  }
+
+  // ゲッターのテスト
+  TEST(LineTracerTest, getIsLeftEdge)
+  {
+    bool isLeftEdge = true;
+    LineTracer lineTracer(isLeftEdge);
+
+    bool expected = isLeftEdge;
+    bool actual = lineTracer.getIsLeftEdge();
+    EXPECT_EQ(expected, actual);
+  }
+
+  // セッターのテスト
+  TEST(LineTracerTest, setIsLeftEdge)
+  {
+    bool isLeftEdge = true;
+    LineTracer lineTracer(isLeftEdge);
+    lineTracer.setIsLeftEdge(false);
+
+    bool expected = false;
+    bool actual = lineTracer.getIsLeftEdge();
+    EXPECT_EQ(expected, actual);
+  }
+
+  // トグルのテスト
+  TEST(LineTracerTest, toggleEdge)
+  {
+    bool isLeftEdge = true;
+    LineTracer lineTracer(isLeftEdge);
+    lineTracer.toggleEdge();
+
+    bool expected = !isLeftEdge;
+    bool actual = lineTracer.getIsLeftEdge();
+    EXPECT_EQ(expected, actual);
+  }
+}  // namespace etrobocon2022_test

--- a/test/LineTracerTest.cpp
+++ b/test/LineTracerTest.cpp
@@ -20,20 +20,22 @@ namespace etrobocon2022_test {
     int pwm = 100;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    // ライントレース前のモータ回転数
+    // 初期値から期待する走行距離を求める
     int initialRightCount = measurer.getRightCount();
     int initialLeftCount = measurer.getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount) + targetDistance;
+    int error = 10;  // 許容誤差
 
-    // 直線を想定してライントレースを実行
+    // ライントレースを実行
     lineTracer.run(targetDistance, targetBrightness, pwm, gain);
 
-    int rightCount = measurer.getRightCount() - initialRightCount;
-    int leftCount = measurer.getLeftCount() - initialLeftCount;
-    int actual = std::abs(rightCount - leftCount);  // 両輪の回転差
-    int expectedError = 50;                         // 両輪の回転の予測誤差（deg）
+    // ライントレース後の走行距離
+    int rightCount = measurer.getRightCount();
+    int leftCount = measurer.getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
 
-    // ライントレース後の両輪の回転差が予測誤差以下である．
-    EXPECT_GE(expectedError, actual);
+    EXPECT_LE(expected, actual);  // ライントレース後に走行した距離が期待する走行距離以上である
+    EXPECT_GE(expected + error, actual);  // ライントレース後に走行した距離が許容誤差以内である
   }
 
   TEST(LineTracerTest, runRightEdge)
@@ -46,20 +48,22 @@ namespace etrobocon2022_test {
     int pwm = 100;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    // ライントレース前のモータ回転数
+    // 初期値から期待する走行距離を求める
     int initialRightCount = measurer.getRightCount();
     int initialLeftCount = measurer.getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount) + targetDistance;
+    int error = 10;  // 許容誤差
 
-    // 直線を想定してライントレースを実行
+    // ライントレースを実行
     lineTracer.run(targetDistance, targetBrightness, pwm, gain);
 
-    int rightCount = measurer.getRightCount() - initialRightCount;
-    int leftCount = measurer.getLeftCount() - initialLeftCount;
-    int actual = std::abs(rightCount - leftCount);  // 両輪の回転差
-    int expectedError = 50;                         // 両輪の回転の予測誤差（deg）
+    // ライントレース後の走行距離
+    int rightCount = measurer.getRightCount();
+    int leftCount = measurer.getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
 
-    // ライントレース後の両輪の回転差が予測誤差以下である．
-    EXPECT_GE(expectedError, actual);
+    EXPECT_LE(expected, actual);  // ライントレース後に走行した距離が期待する走行距離以上である
+    EXPECT_GE(expected + error, actual);  // ライントレース後に走行した距離が許容誤差以内である
   }
 
   TEST(LineTracerTest, runZeroPWM)
@@ -72,20 +76,20 @@ namespace etrobocon2022_test {
     int pwm = 0;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    // ライントレース前のモータ回転数
+    // 初期値から期待する走行距離を求める
     int initialRightCount = measurer.getRightCount();
     int initialLeftCount = measurer.getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
 
-    // 直線を想定してライントレースを実行
+    // ライントレースを実行
     lineTracer.run(targetDistance, targetBrightness, pwm, gain);
 
-    int rightCount = measurer.getRightCount() - initialRightCount;
-    int leftCount = measurer.getLeftCount() - initialLeftCount;
-    int actual = std::abs(rightCount - leftCount);  // 両輪の回転差
-    int expectedError = 0;                          // 両輪の回転の予測誤差（deg）
+    // ライントレース後の走行距離
+    int rightCount = measurer.getRightCount();
+    int leftCount = measurer.getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
 
-    // ライントレース後の両輪の回転差が予測誤差以下である．
-    EXPECT_EQ(expectedError, actual);
+    EXPECT_EQ(expected, actual);  // ライントレース前後で走行距離に変化はない
   }
 
   TEST(LineTracerTest, runBack)
@@ -98,20 +102,48 @@ namespace etrobocon2022_test {
     int pwm = -100;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    // ライントレース前のモータ回転数
+    // 初期値から期待する走行距離を求める
     int initialRightCount = measurer.getRightCount();
     int initialLeftCount = measurer.getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount) - targetDistance;
+    int error = 10;  // 許容誤差
 
-    // 直線を想定してライントレースを実行
+    // ライントレースを実行
     lineTracer.run(targetDistance, targetBrightness, pwm, gain);
 
-    int rightCount = measurer.getRightCount() - initialRightCount;
-    int leftCount = measurer.getLeftCount() - initialLeftCount;
-    int actual = std::abs(rightCount - leftCount);  // 両輪の回転差
-    int expectedError = 50;                         // 両輪の回転の予測誤差（deg）
+    // ライントレース後の走行距離
+    int rightCount = measurer.getRightCount();
+    int leftCount = measurer.getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
 
-    // ライントレース後の両輪の回転差が予測誤差以下である．
-    EXPECT_GE(expectedError, actual);
+    EXPECT_GE(expected, actual);  // ライントレース後に走行した距離が期待する走行距離以下である
+    EXPECT_LE(expected - error, actual);  // ライントレース後に走行した距離が許容誤差以内である
+  }
+
+  TEST(LineTracerTest, runToColor)
+  {
+    Measurer measurer;
+    bool isLeftEdge = true;
+    LineTracer lineTracer(isLeftEdge);
+    COLOR targetColor = COLOR::GREEN;
+    double targetBrightness = 45;
+    int pwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = measurer.getRightCount();
+    int initialLeftCount = measurer.getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    // 緑までライントレースを実行
+    lineTracer.runToColor(targetColor, targetBrightness, pwm, gain);
+
+    // ライントレース後の走行距離
+    int rightCount = measurer.getRightCount();
+    int leftCount = measurer.getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LT(expected, actual);  // 初期値より少しでも進んでいる
   }
 
   // ゲッターのテスト

--- a/test/MeasurerTest.cpp
+++ b/test/MeasurerTest.cpp
@@ -7,14 +7,26 @@
 #include "Measurer.h"
 #include <gtest/gtest.h>
 
+// rgb_raw_tの比較用関数
+bool eqRgb(rgb_raw_t rgb1, rgb_raw_t rgb2)
+{
+  return rgb1.r == rgb2.r && rgb1.g == rgb2.g && rgb1.b == rgb2.b;
+}
+
 namespace etrobocon2022_test {
-  TEST(getRawColorTest, getRawColorRed)
+  TEST(MeasurerTest, getRawColor)
   {
     Measurer measurer;
-    int expected1 = 8;
-    int expected2 = 111;
-    int actual = measurer.getRawColor().r;
+    rgb_raw_t expected1 = { 8, 9, 10 };       // black
+    rgb_raw_t expected2 = { 104, 101, 146 };  // white
+    rgb_raw_t expected3 = { 111, 19, 19 };    // red
+    rgb_raw_t expected4 = { 120, 108, 71 };   // yellow
+    rgb_raw_t expected5 = { 4, 75, 35 };      // green
+    rgb_raw_t expected6 = { 81, 92, 144 };    // blue
+    rgb_raw_t actual = measurer.getRawColor();
 
-    ASSERT_TRUE(actual == expected1 || actual == expected2);
+    ASSERT_TRUE(eqRgb(actual, expected1) || eqRgb(actual, expected2) || eqRgb(actual, expected3)
+                || eqRgb(actual, expected4) || eqRgb(actual, expected5)
+                || eqRgb(actual, expected6));
   }
 }  // namespace etrobocon2022_test

--- a/test/dummy/ColorSensor.cpp
+++ b/test/dummy/ColorSensor.cpp
@@ -8,7 +8,7 @@
 using namespace ev3api;
 
 //コンストラクタ
-ColorSensor::ColorSensor(ePortS port) : brightnessCount(0) {}
+ColorSensor::ColorSensor(ePortS port) {}
 
 // RGB値を取得
 void ColorSensor::getRawColor(rgb_raw_t& rgb)

--- a/test/dummy/ColorSensor.cpp
+++ b/test/dummy/ColorSensor.cpp
@@ -10,25 +10,28 @@ using namespace ev3api;
 //コンストラクタ
 ColorSensor::ColorSensor(ePortS port) : brightnessCount(0) {}
 
-//明るさを取得
-int ColorSensor::getBrightness()
-{
-  int blackValue = 3;   // 黒の上で明るさを取得したときの値
-  int whiteValue = 93;  // 白の上で明るさを取得したときの値
-
-  //白と黒を交互に返す
-  brightnessCount++;
-  return brightnessCount % 2 == 0 ? blackValue : whiteValue;
-}
-
 // RGB値を取得
 void ColorSensor::getRawColor(rgb_raw_t& rgb)
 {
-  int index = rand() % 2;
-  if(index == 0) {
-    rgb = { 8, 9, 10 };  // black
-  } else {
-    rgb = { 111, 19, 19 };  // red
+  int index = rand() % 6;
+  switch(index) {
+    case 0:
+      rgb = { 8, 9, 10 };  // black
+      break;
+    case 1:
+      rgb = { 104, 101, 146 };  // white
+      break;
+    case 2:
+      rgb = { 111, 19, 19 };  // red
+      break;
+    case 3:
+      rgb = { 120, 108, 71 };  // yellow
+      break;
+    case 4:
+      rgb = { 4, 75, 35 };  // green
+      break;
+    case 5:
+      rgb = { 81, 92, 144 };  // blue
+      break;
   }
-  //他の色のダミーも後々追加する予定
 }

--- a/test/dummy/ColorSensor.cpp
+++ b/test/dummy/ColorSensor.cpp
@@ -8,12 +8,17 @@
 using namespace ev3api;
 
 //コンストラクタ
-ColorSensor::ColorSensor(ePortS port) {}
+ColorSensor::ColorSensor(ePortS port) : brightnessCount(0) {}
 
 //明るさを取得
 int ColorSensor::getBrightness()
 {
-  return brightness;
+  int blackValue = 3;   // 黒の上で明るさを取得したときの値
+  int whiteValue = 93;  // 白の上で明るさを取得したときの値
+
+  //白と黒を交互に返す
+  brightnessCount++;
+  return brightnessCount % 2 == 0 ? blackValue : whiteValue;
 }
 
 // RGB値を取得

--- a/test/dummy/ColorSensor.h
+++ b/test/dummy/ColorSensor.h
@@ -27,12 +27,6 @@ namespace ev3api {
     explicit ColorSensor(ePortS port);
 
     /**
-     * 明るさを取得
-     * @return 反射光の強さ(0-100)
-     */
-    int getBrightness();  //明るさを取得
-
-    /**
      * RGB値を取得
      * @return RGBを保持するクラス
      */

--- a/test/dummy/ColorSensor.h
+++ b/test/dummy/ColorSensor.h
@@ -19,8 +19,6 @@ namespace ev3api {
   //カラーセンサクラス
   class ColorSensor {
    public:
-    int brightness = 0;
-
     /**
      * コンストラクタ
      * @param port カラーセンサポート番号
@@ -39,6 +37,9 @@ namespace ev3api {
      * @return RGBを保持するクラス
      */
     void getRawColor(rgb_raw_t& rgb);
+
+   private:
+    int brightnessCount;
   };
 }  // namespace ev3api
 

--- a/test/dummy/ColorSensor.h
+++ b/test/dummy/ColorSensor.h
@@ -31,9 +31,6 @@ namespace ev3api {
      * @return RGBを保持するクラス
      */
     void getRawColor(rgb_raw_t& rgb);
-
-   private:
-    int brightnessCount;
   };
 }  // namespace ev3api
 


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- ライントレースをするLineTracerクラスを追加
- ライントレースエリアを攻略するLineTraceAreaクラスを追加
- ダミーのColorSensor::getBrightness()で白と黒の値を交互に返すように変更
- EtRobocon2022.cppにライントレースエリアを攻略する処理を追加
- 
# 動作テスト
実機でLコースを10回走らせた
- ゴール率: 10/10
- 走行タイム: 約20秒

https://user-images.githubusercontent.com/56989154/176283941-7648ab24-83f2-4cf2-96ad-343074c0cbd1.mov

# 問題点
- ゴール後の緑のマーカーで止まる処理がかなり不安定
- 白と黒の間を緑と認識してしまうので，色識別クラスの精度を向上する必要がある