### PR TITLE
close #43 実機でコンパイルが通らない問題の解決

### DIFF
--- a/module/API/Controller.h
+++ b/module/API/Controller.h
@@ -6,10 +6,10 @@
 #ifndef CONTROLLER_H
 #define CONTROLLER_H
 
+#include "Measurer.h"
 #include "ev3api.h"
 #include "Motor.h"
 #include "Clock.h"
-#include "Measurer.h"
 
 class Controller {
  public:

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "EtRobocon2022.h"
+#include "LineTraceArea.h"
 
 void EtRobocon2022::start()
 {

--- a/module/EtRobocon2022.h
+++ b/module/EtRobocon2022.h
@@ -7,8 +7,6 @@
 #ifndef ETROBOCON2022_H
 #define ETROBOCON2022_H
 
-#include "LineTraceArea.h"
-
 class EtRobocon2022 {
  public:
   static void start();


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- EtRobocon2022.hに記述していたinclude文をEtRobocon2022.cppに移動
- Controller.hで`<algorithm>`(from #include "Measurer.h")が`ev3api.h`より後に読み込まれていたので修正（詳しくはslackの#バグレポート参照）

# 動作テスト
- 実機でコンパイルが通ることを確認
- 実機で実行し，正常に動作することを確認

# 現状分かっていること
- EtRobocon2022.hでinclude文を記述すると以下のようなエラーメッセージが出る
```
In file included from /usr/include/stdio.h:33,
                 from ../common/ev3api/include/ev3api.h:13,
                 from /home/katlab/work/RasPike/sdk/workspace/etrobocon2022/app.h:11,
                 from /home/katlab/work/RasPike/sdk/workspace/etrobocon2022/app.cpp:7:
../../include/t_stddef.h:221:32: error: template definition of non-template 'struct std::alignment_of<_Tp>::<unnamed>'
  221 | #define alignof(type) offsetof(struct { char field1; type field2; }, field2)
      |                                ^~~~~~
../../include/t_stddef.h:221:39: error: types may not be defined within '__builtin_offsetof'
  221 | #define alignof(type) offsetof(struct { char field1; type field2; }, field2)
      |                                       ^
../../include/t_stddef.h:221:39: error: types may not be defined within '__builtin_offsetof'
  221 | #define alignof(type) offsetof(struct { char field1; type field2; }, field2)
      |                                       ^
```
- EtRobocon2022.cppにinclude文を記述すれば問題なく動作する
- `LineTraceArea.h`は恐らくEtRobocon2022でしか使わないので，インクルードガードしてなくてもいいかもしれないけど，後々必要になる可能性はある