### PR TITLE
close #59 カラーブロックを運ぶ

### DIFF
--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -7,7 +7,7 @@
 #include "EtRobocon2022.h"
 #include "LineTraceArea.h"
 #include "Calibrator.h"
-#include "ColorBlockCarrier.h"
+
 void EtRobocon2022::start()
 {
   bool isLeftCourse = true;

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -7,6 +7,7 @@
 #include "EtRobocon2022.h"
 #include "LineTraceArea.h"
 #include "Calibrator.h"
+#include "BonusBlockCarrier.h"
 
 void EtRobocon2022::start()
 {
@@ -24,4 +25,7 @@ void EtRobocon2022::start()
 
   // ライントレースエリアを走行する
   LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
+
+  // ボーナスブロック運搬を実行
+  BonusBlockCarrier::run(targetBrightness);
 }

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -7,8 +7,7 @@
 #include "EtRobocon2022.h"
 #include "LineTraceArea.h"
 #include "Calibrator.h"
-#include "BonusBlockCarrier.h"
-
+#include "ColorBlockCarrier.h"
 void EtRobocon2022::start()
 {
   bool isLeftCourse = true;
@@ -23,9 +22,9 @@ void EtRobocon2022::start()
   // 合図を送るまで待機する
   calibrator.waitForStart();
 
-  // ライントレースエリアを走行する
-  LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
+  // // ライントレースエリアを走行する
+  // LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
 
-  // ボーナスブロック運搬を実行
-  BonusBlockCarrier::run(targetBrightness);
+  // カラーブロック運搬を実行
+  ColorBlockCarrier::run(targetBrightness);
 }

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -22,6 +22,6 @@ void EtRobocon2022::start()
   // 合図を送るまで待機する
   calibrator.waitForStart();
 
-  // // ライントレースエリアを走行する
+  // ライントレースエリアを走行する
   LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
 }

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -23,7 +23,5 @@ void EtRobocon2022::start()
   calibrator.waitForStart();
 
   // // ライントレースエリアを走行する
-  // LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
-  // カラーブロック運搬を実行
-  ColorBlockCarrier::run(targetBrightness);
+  LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
 }

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -24,7 +24,6 @@ void EtRobocon2022::start()
 
   // // ライントレースエリアを走行する
   // LineTraceArea::runLineTraceArea(isLeftCourse, targetBrightness);
-
   // カラーブロック運搬を実行
   ColorBlockCarrier::run(targetBrightness);
 }

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -18,41 +18,41 @@ void ColorBlockCarrier::run(int targetBrightness)
   // straightRunner.run(40, -50);
 
   // 緑を認識するまでライントレース
-  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
+  lineTracer.runToColor(COLOR::GREEN, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
 
-  // // 右に38度回頭
-  // rotation.rotateRight(38, 70);
+  // 右に38度回頭
+  rotation.rotateRight(38, 70);
 
-  // // ブロックまで直進
-  // straightRunner.run(145, 60);
+  // ブロックまで直進
+  straightRunner.run(145, 60);
 
-  // // 右に52度回頭
-  // rotation.rotateRight(52, 70);
+  // 右に52度回頭
+  rotation.rotateRight(52, 70);
 
-  // // 黒線まで直進
-  // straightRunner.run(152, 60);
+  // 黒線まで直進
+  straightRunner.run(152, 60);
 
-  // // 右に90度回頭
-  // rotation.rotateRight(90, 70);
+  // 右に90度回頭
+  rotation.rotateRight(90, 70);
 
-  // // 直進を安定させるために1秒待機
-  // controller.sleep(1000000);
+  // 直進を安定させるために1秒待機
+  controller.sleep(1000000);
 
-  // // 黄色を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 黄色を認識するまでライントレース
+  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // // 交点内を直進
-  // straightRunner.run(35, 70);
+  // 交点内を直進
+  straightRunner.run(35, 70);
 
-  // // 赤を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 赤を認識するまでライントレース
+  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // // 交点内を直進
-  // straightRunner.run(80, 70);
+  // 交点内を直進
+  straightRunner.run(80, 70);
 
-  // // 赤を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 赤を認識するまでライントレース
+  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // // 交点内を直進
-  // straightRunner.run(35, 70);
+  // 交点内を直進
+  straightRunner.run(35, 70);
 }

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -14,45 +14,45 @@ void ColorBlockCarrier::run(int targetBrightness)
   LineTracer lineTracer(true);
   Controller controller;
 
-  // 交点内を直進
-  straightRunner.run(40, -50);
+  // // 交点内を直進
+  // straightRunner.run(40, -50);
 
   // 緑を認識するまでライントレース
-  lineTracer.runToColor(COLOR::GREEN, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
+  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
 
-  // 右に38度回頭
-  rotation.rotateRight(38, 70);
+  // // 右に38度回頭
+  // rotation.rotateRight(38, 70);
 
-  // ブロックまで直進
-  straightRunner.run(145, 60);
+  // // ブロックまで直進
+  // straightRunner.run(145, 60);
 
-  // 右に52度回頭
-  rotation.rotateRight(52, 70);
+  // // 右に52度回頭
+  // rotation.rotateRight(52, 70);
 
-  // 黒線まで直進
-  straightRunner.run(152, 60);
+  // // 黒線まで直進
+  // straightRunner.run(152, 60);
 
-  // 右に90度回頭
-  rotation.rotateRight(90, 70);
+  // // 右に90度回頭
+  // rotation.rotateRight(90, 70);
 
-  // 直進を安定させるために1秒待機
-  controller.sleep(1000000);
+  // // 直進を安定させるために1秒待機
+  // controller.sleep(1000000);
 
-  // 黄色を認識するまでライントレース
-  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // // 黄色を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(35, 70);
+  // // 交点内を直進
+  // straightRunner.run(35, 70);
 
-  // 赤を認識するまでライントレース
-  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // // 赤を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(80, 70);
+  // // 交点内を直進
+  // straightRunner.run(80, 70);
 
-  // 赤を認識するまでライントレース
-  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // // 赤を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(35, 70);
+  // // 交点内を直進
+  // straightRunner.run(35, 70);
 }

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -16,41 +16,41 @@ void ColorBlockCarrier::run(int targetBrightness)
   Controller controller;
 
   // 交点内を直進
-  straightRunner.run(10, -50);
+  straightRunner.run(40, -50);
 
   // 緑を認識するまでライントレース
   lineTracer.runToColor(COLOR::GREEN, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
 
-  // // 右に45度回頭
-  // rotation.rotateRight(45, 70);
+  // 右に38度回頭
+  rotation.rotateRight(38, 70);
 
-  // // ブロックまで直進
-  // straightRunner.run(34, 50);
+  // ブロックまで直進
+  straightRunner.run(145, 60);
 
-  // // 右に45度回頭
-  // rotation.rotateRight(45, 70);
+  // 右に52度回頭
+  rotation.rotateRight(52, 70);
 
-  // // 黒線まで直進
-  // straightRunner.run(24, 50);
+  // 黒線まで直進
+  straightRunner.run(152, 60);
 
-  // // 右に90度回頭
-  // rotation.rotateRight(90, 70);
+  // 右に90度回頭
+  rotation.rotateRight(90, 70);
 
-  // // 黄色を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
+  // 直進を安定させるために1秒待機
+  controller.sleep(1000000);
 
-  // // 交点内を直進
-  // straightRunner.run(5, 50);
+  // 黄色を認識するまでライントレース
+  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 交点内を直進
+  straightRunner.run(35, 70);
 
-  // // 赤を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::RED, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
+  // 赤を認識するまでライントレース
+  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 交点内を直進
+  straightRunner.run(80, 70);
 
-  // // 交点内を直進
-  // straightRunner.run(5, 50);
-
-  // // 赤を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::RED, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
-
-  // // 交点内を直進
-  // straightRunner.run(5, 50);
+  // 赤を認識するまでライントレース
+  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 交点内を直進
+  straightRunner.run(35, 70);
 }

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -21,19 +21,22 @@ void ColorBlockCarrier::run(int targetBrightness)
   lineTracer.runToColor(COLOR::GREEN, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
 
   // 右に38度回頭
-  rotation.rotateRight(38, 70);
+  rotation.rotateRight(35, 60);
 
   // ブロックまで直進
-  straightRunner.run(145, 60);
+  straightRunner.run(150, 60);
 
   // 右に52度回頭
-  rotation.rotateRight(52, 70);
+  rotation.rotateRight(55, 60);
 
   // 黒線まで直進
-  straightRunner.run(152, 60);
+  straightRunner.run(145, 60);
 
   // 右に90度回頭
-  rotation.rotateRight(90, 70);
+  rotation.rotateRight(90, 60);
+
+  // 直進を安定させるために1秒待機
+  controller.sleep(1000000);
 
   // 直進を安定させるために1秒待機
   controller.sleep(1000000);

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -7,7 +7,6 @@
 #include "ColorBlockCarrier.h"
 
 // Lコースの下のベースエリアへの設置処理のみ実装
-// TODO: Lコース上左右, Rコース上下左右のベースエリアに設置する処理を追加する
 void ColorBlockCarrier::run(int targetBrightness)
 {
   Rotation rotation;
@@ -41,16 +40,19 @@ void ColorBlockCarrier::run(int targetBrightness)
 
   // 黄色を認識するまでライントレース
   lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+
   // 交点内を直進
   straightRunner.run(35, 70);
 
   // 赤を認識するまでライントレース
   lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+
   // 交点内を直進
   straightRunner.run(80, 70);
 
   // 赤を認識するまでライントレース
   lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+
   // 交点内を直進
   straightRunner.run(35, 70);
 }

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -16,41 +16,41 @@ void ColorBlockCarrier::run(int targetBrightness)
   Controller controller;
 
   // 交点内を直進
-  straightRunner.run(5, -50);
+  straightRunner.run(10, -50);
 
   // 緑を認識するまでライントレース
   lineTracer.runToColor(COLOR::GREEN, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
 
-  // 右に45度回頭
-  rotation.rotateRight(45, 70);
+  // // 右に45度回頭
+  // rotation.rotateRight(45, 70);
 
-  // ブロックまで直進
-  straightRunner.run(34, 50);
+  // // ブロックまで直進
+  // straightRunner.run(34, 50);
 
-  // 右に45度回頭
-  rotation.rotateRight(45, 70);
+  // // 右に45度回頭
+  // rotation.rotateRight(45, 70);
 
-  // 黒線まで直進
-  straightRunner.run(24, 50);
+  // // 黒線まで直進
+  // straightRunner.run(24, 50);
 
-  // 右に90度回頭
-  rotation.rotateRight(90, 70);
+  // // 右に90度回頭
+  // rotation.rotateRight(90, 70);
 
-  // 黄色を認識するまでライントレース
-  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
+  // // 黄色を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(5, 50);
+  // // 交点内を直進
+  // straightRunner.run(5, 50);
 
-  // 赤を認識するまでライントレース
-  lineTracer.runToColor(COLOR::RED, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
+  // // 赤を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::RED, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(5, 50);
+  // // 交点内を直進
+  // straightRunner.run(5, 50);
 
-  // 赤を認識するまでライントレース
-  lineTracer.runToColor(COLOR::RED, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
+  // // 赤を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::RED, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(5, 50);
+  // // 交点内を直進
+  // straightRunner.run(5, 50);
 }

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -18,41 +18,41 @@ void ColorBlockCarrier::run(int targetBrightness)
   // straightRunner.run(40, -50);
 
   // 緑を認識するまでライントレース
-  lineTracer.runToColor(COLOR::GREEN, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
+  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
 
-  // 右に38度回頭
-  rotation.rotateRight(38, 70);
+  // // 右に38度回頭
+  // rotation.rotateRight(38, 70);
 
-  // ブロックまで直進
-  straightRunner.run(145, 60);
+  // // ブロックまで直進
+  // straightRunner.run(145, 60);
 
-  // 右に52度回頭
-  rotation.rotateRight(52, 70);
+  // // 右に52度回頭
+  // rotation.rotateRight(52, 70);
 
-  // 黒線まで直進
-  straightRunner.run(152, 60);
+  // // 黒線まで直進
+  // straightRunner.run(152, 60);
 
-  // 右に90度回頭
-  rotation.rotateRight(90, 70);
+  // // 右に90度回頭
+  // rotation.rotateRight(90, 70);
 
-  // 直進を安定させるために1秒待機
-  controller.sleep(1000000);
+  // // 直進を安定させるために1秒待機
+  // controller.sleep(1000000);
 
-  // 黄色を認識するまでライントレース
-  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // // 黄色を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(35, 70);
+  // // 交点内を直進
+  // straightRunner.run(35, 70);
 
-  // 赤を認識するまでライントレース
-  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // // 赤を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(80, 70);
+  // // 交点内を直進
+  // straightRunner.run(80, 70);
 
-  // 赤を認識するまでライントレース
-  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // // 赤を認識するまでライントレース
+  // lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // 交点内を直進
-  straightRunner.run(35, 70);
+  // // 交点内を直進
+  // straightRunner.run(35, 70);
 }

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -14,45 +14,45 @@ void ColorBlockCarrier::run(int targetBrightness)
   LineTracer lineTracer(true);
   Controller controller;
 
-  // // 交点内を直進
-  // straightRunner.run(40, -50);
+  // 交点内を直進
+  straightRunner.run(40, -50);
 
   // 緑を認識するまでライントレース
-  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
+  lineTracer.runToColor(COLOR::GREEN, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
 
-  // // 右に38度回頭
-  // rotation.rotateRight(38, 70);
+  // 右に38度回頭
+  rotation.rotateRight(38, 70);
 
-  // // ブロックまで直進
-  // straightRunner.run(145, 60);
+  // ブロックまで直進
+  straightRunner.run(145, 60);
 
-  // // 右に52度回頭
-  // rotation.rotateRight(52, 70);
+  // 右に52度回頭
+  rotation.rotateRight(52, 70);
 
-  // // 黒線まで直進
-  // straightRunner.run(152, 60);
+  // 黒線まで直進
+  straightRunner.run(152, 60);
 
-  // // 右に90度回頭
-  // rotation.rotateRight(90, 70);
+  // 右に90度回頭
+  rotation.rotateRight(90, 70);
 
-  // // 直進を安定させるために1秒待機
-  // controller.sleep(1000000);
+  // 直進を安定させるために1秒待機
+  controller.sleep(1000000);
 
-  // // 黄色を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 黄色を認識するまでライントレース
+  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // // 交点内を直進
-  // straightRunner.run(35, 70);
+  // 交点内を直進
+  straightRunner.run(35, 70);
 
-  // // 赤を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 赤を認識するまでライントレース
+  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // // 交点内を直進
-  // straightRunner.run(80, 70);
+  // 交点内を直進
+  straightRunner.run(80, 70);
 
-  // // 赤を認識するまでライントレース
-  // lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
+  // 赤を認識するまでライントレース
+  lineTracer.runToColor(COLOR::RED, targetBrightness, 50, PidGain(0.1, 0.08, 0.08));
 
-  // // 交点内を直進
-  // straightRunner.run(35, 70);
+  // 交点内を直進
+  straightRunner.run(35, 70);
 }

--- a/module/Motion/ColorBlockCarrier.cpp
+++ b/module/Motion/ColorBlockCarrier.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file ColorBlockCarrier.cpp
+ * @brief カラーブロックをベースエリアまで運搬する
+ * @author sap2368
+ */
+
+#include "ColorBlockCarrier.h"
+
+// Lコースの下のベースエリアへの設置処理のみ実装
+// TODO: Lコース上左右, Rコース上下左右のベースエリアに設置する処理を追加する
+void ColorBlockCarrier::run(int targetBrightness)
+{
+  Rotation rotation;
+  StraightRunner straightRunner;
+  LineTracer lineTracer(true);
+  Controller controller;
+
+  // 交点内を直進
+  straightRunner.run(5, -50);
+
+  // 緑を認識するまでライントレース
+  lineTracer.runToColor(COLOR::GREEN, targetBrightness, -40, PidGain(0.1, 0.08, 0.08));
+
+  // 右に45度回頭
+  rotation.rotateRight(45, 70);
+
+  // ブロックまで直進
+  straightRunner.run(34, 50);
+
+  // 右に45度回頭
+  rotation.rotateRight(45, 70);
+
+  // 黒線まで直進
+  straightRunner.run(24, 50);
+
+  // 右に90度回頭
+  rotation.rotateRight(90, 70);
+
+  // 黄色を認識するまでライントレース
+  lineTracer.runToColor(COLOR::YELLOW, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
+
+  // 交点内を直進
+  straightRunner.run(5, 50);
+
+  // 赤を認識するまでライントレース
+  lineTracer.runToColor(COLOR::RED, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
+
+  // 交点内を直進
+  straightRunner.run(5, 50);
+
+  // 赤を認識するまでライントレース
+  lineTracer.runToColor(COLOR::RED, targetBrightness, 40, PidGain(0.1, 0.08, 0.08));
+
+  // 交点内を直進
+  straightRunner.run(5, 50);
+}

--- a/module/Motion/ColorBlockCarrier.h
+++ b/module/Motion/ColorBlockCarrier.h
@@ -1,0 +1,26 @@
+/**
+ * @file ColorBlockCarrier.h
+ * @brief カラーブロックをベースエリアまで運搬する
+ * @author sap2368
+ */
+
+#ifndef COLOR_BLOCK_CARRIER_H
+#define COLOR_BLOCK_CARRIER_H
+
+#include "Rotation.h"
+#include "LineTracer.h"
+#include "StraightRunner.h"
+#include "Controller.h"
+
+class ColorBlockCarrier {
+ public:
+  /**
+   * ベースエリアにボーナスブロックを運ぶ
+   * @param targetBrightness 目標輝度
+   */
+  static void run(int targetBrightness);
+
+ private:
+  ColorBlockCarrier();  // インスタンス化を禁止する
+};
+#endif

--- a/module/Motion/ColorBlockCarrier.h
+++ b/module/Motion/ColorBlockCarrier.h
@@ -15,7 +15,7 @@
 class ColorBlockCarrier {
  public:
   /**
-   * ベースエリアにボーナスブロックを運ぶ
+   * ベースエリアにカラーブロックを運ぶ
    * @param targetBrightness 目標輝度
    */
   static void run(int targetBrightness);

--- a/test/ColorBlockCarrierTest.cpp
+++ b/test/ColorBlockCarrierTest.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file ColorBlockCarrierTest.cpp
+ * @brief ColorBlockCarrierクラスのテスト
+ * @author sap2368
+ */
+
+#include "ColorBlockCarrier.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2022_test {
+
+  // 呼び出すだけのテスト
+  TEST(ColorBlockCarrierTest, run)
+  {
+    int targetBrightness = 45;
+
+    // ボーナスブロック運搬を実行
+    ColorBlockCarrier::run(targetBrightness);
+  }
+}  // namespace etrobocon2022_test

--- a/test/ColorBlockCarrierTest.cpp
+++ b/test/ColorBlockCarrierTest.cpp
@@ -14,7 +14,7 @@ namespace etrobocon2022_test {
   {
     int targetBrightness = 45;
 
-    // ボーナスブロック運搬を実行
+    // カラーブロック運搬を実行
     ColorBlockCarrier::run(targetBrightness);
   }
 }  // namespace etrobocon2022_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- ColorBlockCarrierクラスの追加
# 動作テスト
- 実機において、軽いブロックと重いブロックの設置をそれぞれ20回ずつ行った
## 実験方法
## 実験データ
|  修正前  |  修正後  |
| ---- | ---- |
|  -  |  -  |
|  -  |  -  |

## 実験結果
- 重いブロックの設置(14/20)
- 軽いブロックの設置(10/20)
## 添付資料
- 成功例

https://user-images.githubusercontent.com/92567209/179598284-96189aaf-64f7-48b0-857b-082dea01dc5c.MOV

- 失敗例1(エッジを認識できなかった)

https://user-images.githubusercontent.com/92567209/179599533-aa6e5407-6089-4575-99a1-c894904ec691.MOV

- 失敗例2(黒線を緑と認識しノードに到着する前に回頭を開始した)

https://user-images.githubusercontent.com/92567209/179599901-c97e8cd9-c3dc-454b-ad22-2157b1c66f43.MOV



