### PR TITLE
close #81 アームを一定の角度に保つタスクを追加

### DIFF
--- a/app.cfg
+++ b/app.cfg
@@ -3,7 +3,8 @@
 INCLUDE("app_common.cfg");
 
 DOMAIN(TDOM_APP) {
-CRE_TSK(MAIN_TASK, { TA_ACT , 0, main_task, MAIN_PRIORITY, STACK_SIZE  * 10 , NULL });
+    CRE_TSK(MAIN_TASK, { TA_ACT , 0, main_task, MAIN_PRIORITY, STACK_SIZE  * 10 , NULL });
+    CRE_TSK(ARM_TASK, { TA_ACT , 0, arm_task, MAIN_PRIORITY + 1, STACK_SIZE  * 10 , NULL });
 }
 
 ATT_MOD("app.o");

--- a/app.cpp
+++ b/app.cpp
@@ -20,34 +20,29 @@ void main_task(intptr_t unused)
 void arm_task(intptr_t unused)
 {
   // 角度を変えるために最低限必要なPWM値
-  static constexpr int MIN_PWM = 20;
+  static constexpr int MIN_PWM = 15;
 
   Measurer measurer;
   Controller controller;
 
-  // 0はRasPike起動時のアームの角度（モータの回転量）
+  // 0はRasPike起動時のアームの角度(モータの回転量)
   int maxCount = 0;
   int currentCount = measurer.getArmMotorCount();
   int prevCount = currentCount - 1;
-  int stopCounter = 0;
-  int direction = 0;
+  int pwm = 0;
   while(true) {
     // 現在のアームの角度を取得する
     currentCount = measurer.getArmMotorCount();
 
-    // 最大の回転量を目標とする
+    // 回転量の最大値(最もアームが低い)を保持する
     if(maxCount < currentCount){
       maxCount = currentCount;
     }
 
-    if(currentCount > prevCount){
-      stopCounter++;
-    }
-
     // アームが下がる(回転量が大きくなる)余地があれば調整する
-    direction = currentCount > prevCount || maxCount > currentCount ? 1 : 0;
-    if(direction > 0) printf("current count: %d\n", currentCount);
-    controller.setArmMotorPwm(MIN_PWM * direction);
+    pwm = (currentCount > prevCount || maxCount > currentCount) ? MIN_PWM : 0;
+    controller.setArmMotorPwm(pwm);
+
     prevCount = currentCount;
     controller.sleep();
   }

--- a/app.cpp
+++ b/app.cpp
@@ -4,9 +4,8 @@
  * @author miyashita64
  */
 
-#include "Measurer.h"
-#include "Controller.h"
 #include "EtRobocon2022.h"
+#include "ArmKeeper.h"
 #include "app.h"
 
 // メインタスク
@@ -19,32 +18,6 @@ void main_task(intptr_t unused)
 // アームを一定に保つタスク
 void arm_task(intptr_t unused)
 {
-  // 角度を変えるために最低限必要なPWM値
-  static constexpr int MIN_PWM = 15;
-
-  Measurer measurer;
-  Controller controller;
-
-  // 0はRasPike起動時のアームの角度(モータの回転量)
-  int maxCount = 0;
-  int currentCount = measurer.getArmMotorCount();
-  int prevCount = currentCount - 1;
-  int pwm = 0;
-  while(true) {
-    // 現在のアームの角度を取得する
-    currentCount = measurer.getArmMotorCount();
-
-    // 回転量の最大値(最もアームが低い)を保持する
-    if(maxCount < currentCount) {
-      maxCount = currentCount;
-    }
-
-    // アームが下がる(回転量が大きくなる)余地があれば調整する
-    pwm = (currentCount > prevCount || maxCount > currentCount) ? MIN_PWM : 0;
-    controller.setArmMotorPwm(pwm);
-
-    prevCount = currentCount;
-    controller.sleep();
-  }
+  ArmKeeper::start();
   ext_tsk();
 }

--- a/app.cpp
+++ b/app.cpp
@@ -35,7 +35,7 @@ void arm_task(intptr_t unused)
     currentCount = measurer.getArmMotorCount();
 
     // 回転量の最大値(最もアームが低い)を保持する
-    if(maxCount < currentCount){
+    if(maxCount < currentCount) {
       maxCount = currentCount;
     }
 

--- a/app.cpp
+++ b/app.cpp
@@ -20,7 +20,7 @@ void main_task(intptr_t unused)
 void arm_task(intptr_t unused)
 {
   // 角度を変えるために最低限必要なPWM値
-  static constexpr int MIN_PWM = 12;
+  static constexpr int MIN_PWM = 20;
 
   Measurer measurer;
   Controller controller;
@@ -28,10 +28,10 @@ void arm_task(intptr_t unused)
   // 0はRasPike起動時のアームの角度（モータの回転量）
   int maxCount = 0;
   int currentCount = measurer.getArmMotorCount();
-  int prevCount = currentCount;
+  int prevCount = currentCount - 1;
+  int stopCounter = 0;
   int direction = 0;
   while(true) {
-    printf("current count: %d\n", currentCount);
     // 現在のアームの角度を取得する
     currentCount = measurer.getArmMotorCount();
 
@@ -40,9 +40,15 @@ void arm_task(intptr_t unused)
       maxCount = currentCount;
     }
 
+    if(currentCount > prevCount){
+      stopCounter++;
+    }
+
     // アームが下がる(回転量が大きくなる)余地があれば調整する
     direction = currentCount > prevCount || maxCount > currentCount ? 1 : 0;
+    if(direction > 0) printf("current count: %d\n", currentCount);
     controller.setArmMotorPwm(MIN_PWM * direction);
+    prevCount = currentCount;
     controller.sleep();
   }
   ext_tsk();

--- a/app.cpp
+++ b/app.cpp
@@ -4,10 +4,38 @@
  * @author miyashita64
  */
 
-#include "app.h"
+#include "Measurer.h"
+#include "Controller.h"
 #include "EtRobocon2022.h"
+#include "app.h"
+
+// メインタスク
 void main_task(intptr_t unused)
 {
   EtRobocon2022::start();
+  ext_tsk();
+}
+
+// アームを水平に保つタスク
+void arm_task(intptr_t unused)
+{
+  // 目標とするアームの角度（モータの回転量）
+  static constexpr int TARGET_COUNT = 0;
+  // 角度を変えるために最低限必要なPWM値
+  static constexpr int MIN_PWM = 10;
+
+  Measurer measurer;
+  Controller controller;
+
+  int currentCount = measurer.getArmMotorCount();
+  int direction = 0;
+  while(true) {
+    // 現在のアームの角度を取得する
+    currentCount = measurer.getArmMotorCount();
+    // 調整の方向を判定する
+    direction = currentCount < TARGET_COUNT ? 1 : currentCount > TARGET_COUNT ? -1 : 0;
+    controller.setArmMotorPwm(MIN_PWM * direction);
+    controller.sleep();
+  }
   ext_tsk();
 }

--- a/app.h
+++ b/app.h
@@ -18,6 +18,7 @@ extern "C" {
 
 #ifndef TOPPERS_MACRO_ONLY
 extern void main_task(intptr_t exinf);  // メインタスク
+extern void arm_task(intptr_t exinf);   // アームを水平に保つタスク
 #endif                                  /* TOPPERS_MACRO_ONLY */
 
 #ifdef __cplusplus

--- a/app.h
+++ b/app.h
@@ -18,7 +18,7 @@ extern "C" {
 
 #ifndef TOPPERS_MACRO_ONLY
 extern void main_task(intptr_t exinf);  // メインタスク
-extern void arm_task(intptr_t exinf);   // アームを水平に保つタスク
+extern void arm_task(intptr_t exinf);   // アームを一定に保つタスク
 #endif                                  /* TOPPERS_MACRO_ONLY */
 
 #ifdef __cplusplus

--- a/module/ArmKeeper.cpp
+++ b/module/ArmKeeper.cpp
@@ -17,6 +17,7 @@ void ArmKeeper::start()
   // 0はRasPike起動時のアームの角度(モータの回転量)
   int maxCount = 0;
   int currentCount = measurer.getArmMotorCount();
+  // currentCountより小さい値で初期化
   int prevCount = currentCount - 1;
   int pwm = 0;
   while(true) {

--- a/module/ArmKeeper.cpp
+++ b/module/ArmKeeper.cpp
@@ -9,7 +9,7 @@
 void ArmKeeper::start()
 {
   // 角度を変えるために最低限必要なPWM値
-  static constexpr int MIN_PWM = 15;
+  static constexpr int MIN_PWM = 30;
 
   Measurer measurer;
   Controller controller;

--- a/module/ArmKeeper.cpp
+++ b/module/ArmKeeper.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file ArmKeeper.cpp
+ * @brief アームを水平に保つクラス
+ * @author miyashita64
+ */
+
+#include "ArmKeeper.h"
+
+void ArmKeeper::start()
+{
+  // 角度を変えるために最低限必要なPWM値
+  static constexpr int MIN_PWM = 15;
+
+  Measurer measurer;
+  Controller controller;
+
+  // 0はRasPike起動時のアームの角度(モータの回転量)
+  int maxCount = 0;
+  int currentCount = measurer.getArmMotorCount();
+  int prevCount = currentCount - 1;
+  int pwm = 0;
+  while(true) {
+    // 現在のアームの角度を取得する
+    currentCount = measurer.getArmMotorCount();
+
+    // 回転量の最大値(最もアームが低い)を保持する
+    if(maxCount < currentCount) {
+      maxCount = currentCount;
+    }
+
+    // アームが下がる(回転量が大きくなる)余地があれば調整する
+    pwm = (currentCount > prevCount || maxCount > currentCount) ? MIN_PWM : 0;
+    controller.setArmMotorPwm(pwm);
+
+    prevCount = currentCount;
+    controller.sleep();
+  }
+}

--- a/module/ArmKeeper.h
+++ b/module/ArmKeeper.h
@@ -1,0 +1,18 @@
+/**
+ * @file ArmKeeper.h
+ * @brief アームを水平に保つクラス
+ * @author miyashita64
+ */
+
+#ifndef ARM_KEEPER_H
+#define ARM_KEEPER_H
+
+#include "Measurer.h"
+#include "Controller.h"
+
+class ArmKeeper {
+ public:
+  static void start();
+};
+
+#endif


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- app.cfgにアームを一定に保つタスクを追加
- app.h, app.cpp にアーム一定に保つ処理を追加

# 動作テスト

## 実験方法
メインタスクに関わらず、アームを一定に保っているか確認する。

## 実験データ
https://user-images.githubusercontent.com/83441177/184893343-fdc895fb-b29e-4dc1-acf6-97d0d36b15ee.MOV

## 実験結果
アームが指定した角度に動くことを確認した。
※RasPikeの充電状態によって、モータの出力が変わる？pwmが10で動いた機体が15でやっと動くようになっていて、RasPike充電後は10でも高速に動いた。

## 添付資料
- [KatLab-MiyazakiUniv/etrobcon2021のタスク設計](https://github.com/KatLab-MiyazakiUniv/etrobocon2021/pull/106)
- [後輩たちのためのEV3rt講座⑧(タスク・周期ハンドラ)](https://qiita.com/koushiro/items/22a10c7dd451291fd95b)