### PR TITLE
close #91 SPIKEの電圧を表示する

### DIFF
--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -1,7 +1,7 @@
 /**
  * @file Measurer.cpp
  * @brief 計測に用いる関数をまとめたラッパークラス
- * @author KakinokiKanta mutotaka0426
+ * @author KakinokiKanta mutotaka0426 sugaken0528
  */
 
 #include "Measurer.h"

--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -80,3 +80,9 @@ int Measurer::getForwardDistance()
 
   return distance;
 }
+
+// SPIKEの電圧を取得
+double Measurer::getVoltage()
+{
+  return ev3_battery_voltage_mV() / 1000;
+}

--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -84,5 +84,5 @@ int Measurer::getForwardDistance()
 // SPIKEの電圧を取得
 double Measurer::getVoltage()
 {
-  return ev3_battery_voltage_mV() / 1000;
+  return (double)ev3_battery_voltage_mV() / 1000.0;
 }

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -75,6 +75,12 @@ class Measurer {
    */
   int getForwardDistance();
 
+  /**
+   * SPIKEの電圧を取得
+   * @return SPIKEの電圧[v]
+   */
+  double getVoltage();
+
  private:
   ev3api::ColorSensor colorSensor;
   ev3api::SonarSensor sonarSensor;

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -1,7 +1,7 @@
 /**
  * @file Measurer.h
  * @brief 計測に用いる関数をまとめたラッパークラス
- * @author KakinokiKanta mutotaka0426
+ * @author KakinokiKanta mutotaka0426 sugaken0528
  */
 
 #ifndef MEASURER_H
@@ -77,7 +77,7 @@ class Measurer {
 
   /**
    * SPIKEの電圧を取得
-   * @return SPIKEの電圧[v]
+   * @return SPIKEの電圧[V]
    */
   double getVoltage();
 

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -13,22 +13,33 @@ Calibrator::Calibrator()
 
 void Calibrator::run()
 {
-  const int BUF_SIZE = 128;
-  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
-
-  // ev3apiの出力と入り混じるので10ミリ秒スリープを入れる
-  controller.sleep();
-
-  // SPIKEの電圧を取得しログを出す
-  double voltage = measurer.getVoltage();
-  snprintf(buf, BUF_SIZE, "SPIKE voltage is %.3lf[V]\n", voltage);
-  logger.logHighlight(buf);
+  // SPIKEの電圧を表示する
+  showVoltage();
 
   // 左右ボタンでコースのLRを選択する
   selectCourse();
 
   // 黒と白の輝度を測定して目標輝度を求める
   measureTargetBrightness();
+}
+
+void Calibrator::showVoltage()
+{
+  constexpr double MAX_VOLTAGE = 8.393;  // SPIKEの電圧の最大値
+  const int BUF_SIZE = 128;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  // SPIKEの電圧を取得しログを出す
+  double voltage = measurer.getVoltage();
+  snprintf(buf, BUF_SIZE, "SPIKE voltage is %.3f[V] (max voltage: %.3f[V])", voltage, MAX_VOLTAGE);
+  logger.logHighlight(buf);
+
+  // SPIKEの電圧が最大値の半分以下になったらWarningを出す
+  if(voltage <= MAX_VOLTAGE / 2) {
+    logger.logWarning("Voltage is low\n");
+  } else {
+    logger.log("");  // Warninがなかった時に改行だけ入れる
+  }
 }
 
 void Calibrator::selectCourse()

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -16,13 +16,13 @@ void Calibrator::run()
   const int BUF_SIZE = 128;
   char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
 
+  // ev3apiの出力と入り混じるので10ミリ秒スリープを入れる
+  controller.sleep();
+
   // SPIKEの電圧を取得しログを出す
   double voltage = measurer.getVoltage();
   snprintf(buf, BUF_SIZE, "SPIKE voltage is %.3lf[V]\n", voltage);
   logger.logHighlight(buf);
-
-  // ev3apiの出力と入り混じるので10ミリ秒スリープを入れる
-  controller.sleep();
 
   // 左右ボタンでコースのLRを選択する
   selectCourse();

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -1,7 +1,7 @@
 /**
  * @file Calibrator.cpp
  * @brief キャリブレーションからスタートまでを担当するクラス
- * @author mutotaka0426
+ * @author mutotaka0426 sugaken0528
  */
 
 #include "Calibrator.h"
@@ -18,7 +18,7 @@ void Calibrator::run()
 
   // SPIKEの電圧を取得しログを出す
   double voltage = measurer.getVoltage();
-  snprintf(buf, BUF_SIZE, "SPIKE voltage is %lf[V]\n", voltage);
+  snprintf(buf, BUF_SIZE, "SPIKE voltage is %.3lf[V]\n", voltage);
   logger.logHighlight(buf);
 
   // ev3apiの出力と入り混じるので10ミリ秒スリープを入れる

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -13,6 +13,14 @@ Calibrator::Calibrator()
 
 void Calibrator::run()
 {
+  const int BUF_SIZE = 128;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  // SPIKEの電圧を取得しログを出す
+  double voltage = measurer.getVoltage();
+  snprintf(buf, BUF_SIZE, "SPIKE voltage is %lf[V]\n", voltage);
+  logger.logHighlight(buf);
+
   // ev3apiの出力と入り混じるので10ミリ秒スリープを入れる
   controller.sleep();
 

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -50,6 +50,11 @@ class Calibrator {
   Logger logger;
 
   /**
+   * SPIKEの電圧を表示する
+   */
+  void showVoltage();
+
+  /**
    * 左右ボタンでLRコースを選択してisLeftCourseをセットする
    */
   void selectCourse();

--- a/test/CalibratorTest.cpp
+++ b/test/CalibratorTest.cpp
@@ -28,6 +28,7 @@ namespace etrobocon2022_test {
   TEST(CalibratorTest, getIsLeftCourse)
   {
     Calibrator calibrator;
+    srand(2);  // voltageが7300が帰ってくるシード値
     calibrator.run();
 
     // 値がランダムに決定されるので標準出力で確認する

--- a/test/dummy/ev3api.h
+++ b/test/dummy/ev3api.h
@@ -1,7 +1,7 @@
 /**
  * @file ev3api.h
  * @brief Cのヘッダファイルのインクルード（ダミー）
- * @author sap2368
+ * @author sap2368 sugaken0528
  */
 #pragma once
 

--- a/test/dummy/ev3api.h
+++ b/test/dummy/ev3api.h
@@ -7,3 +7,4 @@
 
 #include "ev3api_motor.h"
 #include "ev3api_button.h"
+#include "ev3api_voltage.h"

--- a/test/dummy/ev3api_voltage.cpp
+++ b/test/dummy/ev3api_voltage.cpp
@@ -6,7 +6,7 @@
 
 #include "ev3api_voltage.h"
 
-float ev3_battery_voltage_mV()
+int ev3_battery_voltage_mV()
 {
   // SPIKEの電圧の標準値[mV]
   return 7300;

--- a/test/dummy/ev3api_voltage.cpp
+++ b/test/dummy/ev3api_voltage.cpp
@@ -8,6 +8,11 @@
 
 int ev3_battery_voltage_mV()
 {
-  // SPIKEの電圧の標準値[mV]
-  return 7300;
+  int index = rand() % 2;
+  switch(index) {
+    case 0:
+      return 7300;  // SPIKEの電圧の標準値[mV]
+    case 1:
+      return 4196;  // SPIKEの電圧の最大値の半分[mV]
+  }
 }

--- a/test/dummy/ev3api_voltage.cpp
+++ b/test/dummy/ev3api_voltage.cpp
@@ -1,0 +1,13 @@
+/**
+ * @file ev3api_voltage.cpp
+ * @brief 電圧取得関数のダミー
+ * @author sugaken0528
+ */
+
+#include "ev3api_voltage.h"
+
+float ev3_battery_voltage_mV()
+{
+  // SPIKEの電圧の標準値[mV]
+  return 7300;
+}

--- a/test/dummy/ev3api_voltage.h
+++ b/test/dummy/ev3api_voltage.h
@@ -11,6 +11,6 @@
  * @brief SPIKEの電圧を取得
  * @return SPIKEの電圧[mV]
  */
-float ev3_battery_voltage_mV();
+int ev3_battery_voltage_mV();
 
 #endif

--- a/test/dummy/ev3api_voltage.h
+++ b/test/dummy/ev3api_voltage.h
@@ -7,6 +7,8 @@
 #ifndef EV3API_VOLTAGE_H
 #define EV3API_VOLTAGE_H
 
+#include <stdlib.h>
+
 /**
  * @brief SPIKEの電圧を取得
  * @return SPIKEの電圧[mV]

--- a/test/dummy/ev3api_voltage.h
+++ b/test/dummy/ev3api_voltage.h
@@ -1,0 +1,12 @@
+/**
+ * @file ev3api_voltage.h
+ * @brief 電圧取得関数のダミー
+ * @author sugaken0528
+ */
+
+#ifndef EV3API_VOLTAGE_H
+#define EV3API_VOLTAGE_H
+
+float ev3_battery_voltage_mV();
+
+#endif

--- a/test/dummy/ev3api_voltage.h
+++ b/test/dummy/ev3api_voltage.h
@@ -7,6 +7,10 @@
 #ifndef EV3API_VOLTAGE_H
 #define EV3API_VOLTAGE_H
 
+/**
+ * @brief SPIKEの電圧を取得
+ * @return SPIKEの電圧[mV]
+ */
 float ev3_battery_voltage_mV();
 
 #endif


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- MeasurerクラスにSPIKEの電圧を取得するメソッドを追加
- CalibratorクラスにSPIKEの電圧を表示する処理を追加

# 動作テスト
実機においてキャリブレーション時にSPIKEの電圧が表示されることを確認

## 添付資料

![output](https://user-images.githubusercontent.com/62526141/185357532-c18c4264-0cb9-44ab-a7dd-d89f06dbaf7c.png)
