### PR TITLE
close #112 CIが失敗した際にSlackへ通知する

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
+      - name: Try CI
+        run: |
+          exit 1  # CI失敗時にSlackへ通知する処理のテストを行うためにわざと失敗する
+
       # ${{ github.workspace }} を使用するために必要
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -64,3 +64,39 @@ jobs:
           docker run -e APP_NAME=${{ env.APP_NAME }} \
                      -v ${{ github.workspace }}:/tmp/${{ env.APP_NAME }}:rw \
                      ghcr.io/katlab-miyazakiuniv/${{ env.IMAGE }}:${{ env.TAG }}
+
+      # 参考資料
+      # - Slack が提供する GitHub Action "slack-send" を使って GitHub から Slack に通知する - Qiita
+      #     https://qiita.com/seratch/items/28d09eacada09134c96c
+      # - GitHub Actionsで1つ以上のジョブが失敗した場合にSlackに通知する
+      #     https://zenn.dev/ntoy/articles/3e7521cd39a75b
+      # NOTE:
+      #   "Repository: <${{ [以下略]"の部分は、良い感じに改行する方法を見つけられなかった...
+      - name: Failure Notification
+        if: failure()
+        uses: slackapi/slack-github-action@v1.21.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: CI結果: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ job.status }}>"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -91,7 +91,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: `${{ github.ref_name }}`\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
                     }
                   ]
                 }

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -91,7 +91,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
                     }
                   ]
                 }

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -10,10 +10,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Try CI
-        run: |
-          exit 1  # CI失敗時にSlackへ通知する処理のテストを行うためにわざと失敗する
-
       # ${{ github.workspace }} を使用するために必要
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/google-test.yaml
+++ b/.github/workflows/google-test.yaml
@@ -39,7 +39,7 @@ jobs:
                 "elements": [
                   {
                     "type": "mrkdwn",
-                    "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                    "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: `${{ github.ref_name }}`\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
                   }
                 ]
               }

--- a/.github/workflows/google-test.yaml
+++ b/.github/workflows/google-test.yaml
@@ -12,3 +12,39 @@ jobs:
 
     - name: test
       run: ./gtest_all.sh
+
+    # 参考資料
+    # - Slack が提供する GitHub Action "slack-send" を使って GitHub から Slack に通知する - Qiita
+    #     https://qiita.com/seratch/items/28d09eacada09134c96c
+    # - GitHub Actionsで1つ以上のジョブが失敗した場合にSlackに通知する
+    #     https://zenn.dev/ntoy/articles/3e7521cd39a75b
+    # NOTE:
+    #   "Repository: <${{ [以下略]"の部分は、良い感じに改行する方法を見つけられなかった...
+    - name: Failure Notification
+      if: failure()
+      uses: slackapi/slack-github-action@v1.21.0
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":warning: CI結果: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ job.status }}>"
+                }
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/.github/workflows/google-test.yaml
+++ b/.github/workflows/google-test.yaml
@@ -8,10 +8,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Try CI
-      run: |
-        exit 1  # CI失敗時にSlackへ通知する処理のテストを行うためにわざと失敗する
-
     - uses: actions/checkout@v2
 
     - name: test

--- a/.github/workflows/google-test.yaml
+++ b/.github/workflows/google-test.yaml
@@ -39,7 +39,7 @@ jobs:
                 "elements": [
                   {
                     "type": "mrkdwn",
-                    "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                    "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
                   }
                 ]
               }

--- a/.github/workflows/google-test.yaml
+++ b/.github/workflows/google-test.yaml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Try CI
+      run: |
+        exit 1  # CI失敗時にSlackへ通知する処理のテストを行うためにわざと失敗する
+
     - uses: actions/checkout@v2
 
     - name: test


### PR DESCRIPTION
# チェックリスト

- [ ] ~~clang-format している~~
- [ ] ~~コーディング規約に準じている~~
- [X] チケットの完了条件を満たしている

# 変更点
- CI失敗時にSlackへ通知するように変更
>**Note**
>Clang Formatは、エラーが発生しても動作には影響を及ぼさないためSlackへの通知を行わないようにしている。

# 動作テスト

## 実験方法
わざと失敗するCIファイルをPushし、Slackへ通知が飛ぶことを確認した。

## 実験結果
以下、通知実験。
![image (3)](https://user-images.githubusercontent.com/31930148/188319174-c15ad966-0854-4fcf-81ca-fd8cd048375c.jpg)

## 添付資料
- [GitHub Actionsで1つ以上のジョブが失敗した場合にSlackに通知する]()
- [Slack が提供する GitHub Action "slack-send" を使って GitHub から Slack に通知する - Qiita](https://qiita.com/seratch/items/28d09eacada09134c96c)
