### PR TITLE
close #135 ログをファイルに保存する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,14 @@
 # テスト関係
 build/
-logs/
+
+# ディレクトリ
+logfiles/
 
 # シミュレータ自動実行ツール関係
 .cancel-sim-test
 
 # カメラシステムへのメッセージファイル
 scripts/message.txt
-
-# カメラシステムからの受信データ
-transfer_data/*
 
 # Created by https://www.toptal.com/developers/gitignore/api/c++,macos,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=c++,macos,windows

--- a/module/EtRobocon2022.cpp
+++ b/module/EtRobocon2022.cpp
@@ -20,6 +20,9 @@ void EtRobocon2022::start()
   int targetBrightness = (WHITE_BRIGHTNESS + BLACK_BRIGHTNESS) / 2;
   Calibrator calibrator;
 
+  // 強制終了(CTRL+C)のシグナルを登録する
+  signal(SIGINT, sigint);
+
   // サーバを起動する
   system("bash ./etrobocon2022/scripts/serve.sh &");
 
@@ -48,4 +51,15 @@ void EtRobocon2022::start()
 
   // 走行終了のメッセージログを出す
   logger.logHighlight("The run has been completed\n");
+
+  // ログファイルを生成する
+  logger.outputToFile();
+}
+
+void EtRobocon2022::sigint(int _)
+{
+  Logger logger;
+  logger.log("Forced termination.");  // 強制終了のログを出力
+  logger.outputToFile();              // ログファイルを生成
+  _exit(0);                           //システムコールで強制終了
 }

--- a/module/EtRobocon2022.h
+++ b/module/EtRobocon2022.h
@@ -10,10 +10,19 @@
 // ev3api.hを読み込むヘッダは.cppに記述する
 #include "SystemInfo.h"
 #include "Logger.h"
+#include <signal.h>
+#include <unistd.h>
 
 class EtRobocon2022 {
  public:
   static void start();
+
+ private:
+  /**
+   * @brief ログファイルを生成して終了するシグナルハンドラ
+   * @param _ キャッチしたシグナルの値がセットされる(ここでは使用しない)
+   */
+  static void sigint(int _);
 };
 
 #endif

--- a/module/common/Logger.cpp
+++ b/module/common/Logger.cpp
@@ -1,7 +1,7 @@
 /**
  * @file Logger.cpp
  * @brief 動作確認に用いるprintf()関数を所持するクラス
- * @author sap2368
+ * @author sap2368 mutotaka0426
  */
 #include "Logger.h"
 
@@ -9,30 +9,73 @@ Logger::Logger() {}
 
 void Logger::log(const char* logMessage)
 {
-  const char* log = logMessage;
-  printf("%s\n", log);
+  const int BUF_SIZE = 128;
+  char message[BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, BUF_SIZE, "%s\n", logMessage);
+  printf("%s", message);
+
+  strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
 }
 
 void Logger::logWarning(const char* warningMessage)
 {
-  const char* warning = warningMessage;
+  const int BUF_SIZE = 128;
+  char message[BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, BUF_SIZE, "%s\n", warningMessage);
   printf("\x1b[36m"); /* 文字色をシアンに */
-  printf("Warning: %s\n", warning);
+  printf("Warning: %s", message);
   printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
+
+  strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
 }
 
 void Logger::logError(const char* errorMessage)
 {
-  const char* error = errorMessage;
+  const int BUF_SIZE = 128;
+  char message[BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, BUF_SIZE, "%s\n", errorMessage);
   printf("\x1b[35m"); /* 文字色をマゼンタに */
-  printf("Error: %s\n", error);
+  printf("Error: %s", message);
   printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
+
+  strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
 }
 
 void Logger::logHighlight(const char* highlightLog)
 {
-  const char* hlog = highlightLog;
+  const int BUF_SIZE = 128;
+  char message[BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, BUF_SIZE, "%s\n", highlightLog);
   printf("\x1b[32m"); /* 文字色を緑色に */
-  printf("%s\n", hlog);
+  printf("%s", message);
   printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
+
+  strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
 }
+
+void Logger::outputToFile()
+{
+  FILE* outputFile;
+  const char* fileName = "logfile.txt";  // 暫定のファイル名
+  outputFile = fopen(fileName, "w");     // logfile.txtを作成
+  if(outputFile == NULL) {
+    logWarning("cannot open file");
+    return;
+  }
+  fprintf(outputFile, logs);  // logsの内容をlogfile.txtに書き込む
+  fclose(outputFile);
+
+  /*
+  NOTE: ロボコン環境だと，時刻を取得するtime.hのtime()や，
+  ディレクトリを生成するためのヘッダdirect.hを使用できないため（多分），
+  bashでlogfile.txtの名前をログ生成時刻に変更し，logfiles/に移動する
+  */
+  system("bash ./etrobocon2022/scripts/organizeLogfile.sh &");
+}
+
+void Logger::initLogs()
+{
+  logs[0] = '\0';  // 文字列を初期化
+}
+
+char Logger::logs[65536] = "";  // logsを初期化

--- a/module/common/Logger.h
+++ b/module/common/Logger.h
@@ -1,43 +1,55 @@
 /**
  * @file Logger.h
  * @brief 動作確認に用いるprintf()関数を所持するクラス
- * @author sap2368
+ * @author sap2368 mutotaka0426
  */
 #ifndef LOGGER_H
 #define LOGGER_H
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 class Logger {
  public:
   Logger();
 
   /**
-   * 入力された文字列をLogとしてターミナルに表示
+   * @brief 入力された文字列をLogとしてターミナルに表示
    * @param logMessage 表示するLogメッセージ
    */
   void log(const char* logMessage);
 
   /**
-   * 入力された文字列をwarningMessageとして色を変更し、ターミナルに表示
+   * @brief 入力された文字列をwarningMessageとして色を変更し、ターミナルに表示
    * @param warningMessage 表示するwarningメッセージ
    */
   void logWarning(const char* warningMessage);
 
   /**
-   * 入力された文字列をerrorMessageとして色を変更し、ターミナルに表示
+   * @brief 入力された文字列をerrorMessageとして色を変更し、ターミナルに表示
    * @param errorMessage 表示するerrorメッセージ
    */
   void logError(const char* errorMessage);
 
   /**
-   * 入力された文字列をhighlightLogとして色を変更し、ターミナルに表示
+   * @brief 入力された文字列をhighlightLogとして色を変更し、ターミナルに表示
    * @param hilightLog 表示するhighlightlogメッセージ
    */
   void logHighlight(const char* highlightLog);
 
+  /**
+   * @brief 記録したログをファイル出力する
+   */
+  void outputToFile();
+
+  /**
+   * @brief 記録したログを初期化する
+   */
+  void initLogs();
+
  private:
-  char* Logs;  // システムのログを保持する
+  static char logs[65536];  // システムのログを保持する領域
 };
 
 #endif

--- a/scripts/organizeLogfile.sh
+++ b/scripts/organizeLogfile.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p etrobocon2022/logfiles
+oldName="logfile.txt"
+newName=`date +"%m%d-%H:%M.txt"`
+
+mv -f $oldName etrobocon2022/logfiles/$newName

--- a/test/GameAreaTest.cpp
+++ b/test/GameAreaTest.cpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 #include <gtest/internal/gtest-port.h>
 
+#include "Logger.h"
+
 using namespace std;
 
 namespace etrobocon2022_test {

--- a/test/LoggerTest.cpp
+++ b/test/LoggerTest.cpp
@@ -1,12 +1,13 @@
 /**
  * @file LoggerTest.cpp
  * @brief Loggerクラスをテストする
- * @author sap268
+ * @author sap268 mutotaka0426
  */
 
 #include "Logger.h"
 #include <gtest/gtest.h>
 #include <gtest/internal/gtest-port.h>
+#include <err.h>
 
 namespace etrobocon2022_test {
   TEST(LoggerTest, log)
@@ -57,6 +58,55 @@ namespace etrobocon2022_test {
     logger.logHighlight(logMsg.c_str());
     std::string actual = testing::internal::GetCapturedStdout();  // キャプチャ終了
     ASSERT_STREQ(expected.c_str(), actual.c_str());
+  }
+
+  TEST(LoggerTest, outputToFile)
+  {
+    // 異なるLoggerインスタンスを用いてログを取る
+    Logger logger1;
+    Logger logger2;
+    logger1.initLogs();  // logsを初期化
+    // 各ログ出力の関数を実行する
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    logger1.log("log text");
+    logger2.logWarning("log warning-text");
+    logger1.logError("log error-text");
+    logger2.logHighlight("log highlight-text");
+    std::string _ = testing::internal::GetCapturedStdout();  // キャプチャ終了
+    // 期待出力をセットする
+    std::string expected = "log text\n";
+    expected += "log warning-text\n";
+    expected += "log error-text\n";
+    expected += "log highlight-text\n";
+
+    logger1.outputToFile();  // ログファイルを生成
+
+    const int BUF_SIZE = 64;
+    char filePath[BUF_SIZE] = "./etrobocon2022/logfiles/";
+    char fileName[BUF_SIZE];  // outputToFile()で作成したログファイル
+    const char* cmdline = "ls -rt ./etrobocon2022/logfiles | tail -n 1";
+    FILE* fp = popen(cmdline, "r");  // 上記コマンドにより最新のログファイルを取得する
+    // コマンドの実行結果を取得出来ない場合エラーを出す
+    if((fp = popen(cmdline, "r")) == NULL) {
+      err(EXIT_FAILURE, "%s", cmdline);
+    }
+    fgets(fileName, BUF_SIZE, fp);  // コマンドの実行結果をfileNameにセット
+    pclose(fp);
+    char* endPoint = strchr(fileName, '\n');        // 改行があるポインタを取得
+    if(endPoint != NULL) *endPoint = '\0';          // 改行を削除
+    strncat(filePath, fileName, sizeof(filePath));  // filePathとfileNameを結合する
+
+    const int LINE_SIZE = 256;
+    char line[LINE_SIZE];
+    FILE* file = fopen(filePath, "r");
+    // 直前に生成したログファイルの文字列をセットする
+    std::string actual = "";
+    while(fgets(line, LINE_SIZE, file) != NULL) {
+      actual += line;
+    }
+    fclose(file);
+
+    ASSERT_STREQ(expected.c_str(), actual.c_str());  // ログファイルの中身をテスト
   }
 
 }  // namespace etrobocon2022_test

--- a/test/gtest/gtest_build.sh
+++ b/test/gtest/gtest_build.sh
@@ -19,10 +19,12 @@ if [ -d $buildDir ]; then
     fi
 fi
 
-# NOTE: 実行とテストでカレントディレクトリが異なり，テストの際にファイルパスの指定ができないため，テスト用にdatafiles/ディレクトリを作成・コピーする
+# NOTE: 実行とテストでカレントディレクトリが異なり，テストの際にファイルパスの指定ができないため，テスト用にdatafiles/及びscripts/ディレクトリを作成・コピーする
 mkdir -p build/etrobocon2022/datafiles
+mkdir -p build/etrobocon2022/scripts
 cd build
 cp ../datafiles/*.csv etrobocon2022/datafiles/
+cp ../scripts/*.sh etrobocon2022/scripts/
 
 cmake -DCMAKE_BUILD_TYPE=Coverage ..
 cmake --build .


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- Loggerインスタンスが出力するログを，logsに保持するように拡張
- 競技終了時にlogsをファイル出力するように拡張
- 強制終了時にもlogsをファイル出力する

# 動作テスト
競技終了時及び強制終了時にログファイルが出力されていることを確認．

## 出力例
10月17日の11:21に実行した際の出力．
実行途中で`CTRL+C`で強制終了．
### 1017-11:21.txt
```
SPIKE voltage is 8.379[V] (max voltage: 8.393[V])

Select a Course
>> Set Left Course

Will Run on the Left Course

Press the Center Button on the Black
>> Black Brightness Value is 30
Press the Center Button on the White
>> White Brightness Value is 25

Target Brightness is 27
On standby.

Signal within 5cm from Sonar Sensor.

Run on the Left Course


Run the commands in 'etrobocon2022/datafiles/LineTraceAreaLeft.csv'

Run DistanceLineTracing (targetDistance: 1100.00, targetBrightness: 27, pwm: 70, gain: (0.18,0.04,0.03), isLeftEdge: true)
Run DistanceLineTracing (targetDistance: 410.00, targetBrightness: 27, pwm: 40, gain: (0.60,0.25,0.06), isLeftEdge: true)
Forced termination.
```

## 問題点
CTRL+cをしても稀に強制終了ができない時がある．
しかしCTRL+cをした時点でファイル出力はできており，CTRL+zで終了すれば問題なく終了できる．