### PR TITLE
close #95 アサーションを使ったCalibratorTestをする

### DIFF
--- a/test/CalibratorTest.cpp
+++ b/test/CalibratorTest.cpp
@@ -75,7 +75,7 @@ namespace etrobocon2022_test {
     if(output.find("Will Run on the Left Course") != string::npos) {
       expected = true;  // Lコース
     }
-    // Rightコースト出力されていた場合
+    // Rightコースと出力されていた場合
     else if(output.find("Will Run on the Right Course") != string::npos) {
       expected = false;  // Rコース
     }

--- a/test/CalibratorTest.cpp
+++ b/test/CalibratorTest.cpp
@@ -5,40 +5,107 @@
  */
 
 #include "Calibrator.h"
-#include <string>
 #include <gtest/gtest.h>
+#include <gtest/internal/gtest-port.h>
+#include <time.h>
+
+using namespace std;
 
 namespace etrobocon2022_test {
 
-  // runを呼び出すだけのテスト
   TEST(CalibratorTest, run)
   {
     Calibrator calibrator;
+    srand(2);  // SPIKEの電圧が標準値でLeftコースを選択する乱数シード
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     calibrator.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("Will Run on the Left Course") != string::npos
+                  && output.find("Warning") == string::npos  // Warningがない
+                  && output.find("Error") == string::npos;   // Errorがない
+
+    EXPECT_TRUE(actual);  // 期待した出力がされており，WarningやErrorが出ていないかテスト
   }
 
-  // waitForStartを呼び出すだけのテスト
+  // 電圧のWarningが出るテスト
+  TEST(CalibratorTest, runVoltageWorning)
+  {
+    Calibrator calibrator;
+    srand(0);  // SPIKEの電圧が4196でRightコースを選択する乱数シード
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    calibrator.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual
+        = output.find("Will Run on the Right Course") != string::npos
+          && output.find("Warning: Voltage is low\n") != string::npos  // 電圧のWarningが出ている
+          && output.find("Error") == string::npos;                     // Errorがない
+
+    EXPECT_TRUE(actual);  // 電圧のWarningが出てErrorが出ていないかテスト
+  }
+
   TEST(CalibratorTest, waitForStart)
   {
     Calibrator calibrator;
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     calibrator.waitForStart();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("On standby.\n\nSignal within 5cm from Sonar Sensor.") != string::npos
+                  && output.find("Warning") == string::npos  // Warningがない
+                  && output.find("Error") == string::npos;   // Errorがない
+
+    EXPECT_TRUE(actual);  // 期待した出力がされており，WarningやErrorが出ていないかテスト
   }
 
-  // ゲッターのテスト
   TEST(CalibratorTest, getIsLeftCourse)
   {
     Calibrator calibrator;
-    srand(2);  // voltageが7300が帰ってくるシード値
+    srand((unsigned int)time(NULL));     //現在時刻を元に乱数シードを生成
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     calibrator.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+    bool expected;
 
-    // 値がランダムに決定されるので標準出力で確認する
-    // isLeftCourseの確認
-    bool isLeftCourseActual = calibrator.getIsLeftCourse();
-    std::string str = isLeftCourseActual ? "true" : "false";
-    printf("isLeftCourse = %s\n", str.c_str());
+    // Leftコースと出力されていた場合
+    if(output.find("Will Run on the Left Course") != string::npos) {
+      expected = true;  // Lコース
+    }
+    // Rightコースト出力されていた場合
+    else if(output.find("Will Run on the Right Course") != string::npos) {
+      expected = false;  // Rコース
+    }
+    // 想定していない状況
+    else {
+      expected = NULL;
+    }
 
-    // targetBrightnessの確認
-    int targetBrightnessActual = calibrator.getTargetBrightness();
-    printf("targetBrightness = %d\n", targetBrightnessActual);
+    bool actual = calibrator.getIsLeftCourse();  // 実際のisLeftCourseを取得
+
+    EXPECT_EQ(expected, actual);  // 出力とゲッタの値が等しいかテスト
+  }
+
+  TEST(CalibratorTest, getTargetBrightness)
+  {
+    Calibrator calibrator;
+    srand((unsigned int)time(NULL));     //現在時刻を元に乱数シードを生成
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    calibrator.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    string targetString = "Target Brightness is ";  // 目標輝度値の直前に書かれている文字列
+
+    // 出力された目標輝度値を取得
+    int index = output.find(targetString) + targetString.length();
+    string expectedStr = output.substr(index);  // 輝度値を取得（文字列）
+    int expected = stoi(expectedStr);           // 文字列を整数値に変換
+
+    int actual = calibrator.getTargetBrightness();  // 実際の輝度値を取得
+
+    EXPECT_EQ(expected, actual);  // 出力とゲッタの値が等しいかテスト
   }
 }  // namespace etrobocon2022_test

--- a/test/GameAreaTest.cpp
+++ b/test/GameAreaTest.cpp
@@ -8,8 +8,6 @@
 #include <gtest/gtest.h>
 #include <gtest/internal/gtest-port.h>
 
-#include "Logger.h"
-
 using namespace std;
 
 namespace etrobocon2022_test {


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点

- Calibratorテストで出力していただけのテストを，標準出力が正しいかを判定するテストに変更
- Calibrator::getTargetBrightness()のテストを追加
- ゲッタのテストとして，実行時に表示された値と等しいかを判定するテストに修正

# 動作テスト

CIテストをもって動作テストとする