### PR TITLE
close #145 リアカメラによる回頭角度補正のパラメータの検証

### DIFF
--- a/module/Motion/CorrectingRotation.h
+++ b/module/Motion/CorrectingRotation.h
@@ -32,7 +32,7 @@ class CorrectingRotation : public Motion {
   void logRunning();
 
  private:
-  static constexpr int NO_CORRECTION_ANGLE = 3;  // 補正免除角度 TODO: 値を決定する
+  static constexpr int NO_CORRECTION_ANGLE = 2;  // 補正免除角度(deg)
   int targetAngle;                               // 目標角度(deg) 0~89
   int pwm;                                       // PWM値 0~100
 };

--- a/test/CorrectingRotationTest.cpp
+++ b/test/CorrectingRotationTest.cpp
@@ -24,13 +24,13 @@ namespace etrobocon2022_test {
     CorrectingRotation xRotation(targetAngle, pwm);
     Measurer measurer;
 
-    // rearCamera.shで-3.1を返すように書き換える
+    // rearCamera.shで-2.1を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2022/scripts/rear_camera.sh");
-    system("echo \"echo -3.1\" >> ./etrobocon2022/scripts/rear_camera.sh");
+    system("echo \"echo -2.1\" >> ./etrobocon2022/scripts/rear_camera.sh");
 
     // 期待する車輪ごとの回頭角度(時計回り)
-    double expectedLeft = 3;
-    double expectedRight = -3;
+    double expectedLeft = 2;
+    double expectedRight = -2;
 
     // 一回のsetPWM()でダミーのモータカウントに加算される値はpwm * 0.05
     double error = pwm * 0.05 * TRANSFORM;  // 許容誤差[deg]
@@ -180,13 +180,13 @@ namespace etrobocon2022_test {
     CorrectingRotation xRotation(targetAngle, pwm);
     Measurer measurer;
 
-    // rearCamera.shで86.9を返すように書き換える
+    // rearCamera.shで87.9を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2022/scripts/rear_camera.sh");
-    system("echo \"echo 86.9\" >> ./etrobocon2022/scripts/rear_camera.sh");
+    system("echo \"echo 87.9\" >> ./etrobocon2022/scripts/rear_camera.sh");
 
     // 期待する車輪ごとの回頭角度(時計回り)
-    double expectedLeft = 3;
-    double expectedRight = -3;
+    double expectedLeft = 2;
+    double expectedRight = -2;
 
     // 一回のsetPWM()でダミーのモータカウントに加算される値はpwm * 0.05
     double error = pwm * 0.05 * TRANSFORM;  // 許容誤差[deg]
@@ -258,9 +258,9 @@ namespace etrobocon2022_test {
     CorrectingRotation xRotation(targetAngle, pwm);
     Measurer measurer;
 
-    // rearCamera.shで-3.0を返すように書き換える
+    // rearCamera.shで-2.0を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2022/scripts/rear_camera.sh");
-    system("echo \"echo -3.0\" >> ./etrobocon2022/scripts/rear_camera.sh");
+    system("echo \"echo -2.0\" >> ./etrobocon2022/scripts/rear_camera.sh");
 
     // 期待する車輪ごとの回頭角度(時計回り)
     double expectedLeft = 0;


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点

- 角度補正回頭における補正免除角度を2度に更新

# 検証

[検証結果: #145 補正免除角度の検証](https://docs.google.com/spreadsheets/d/1oWvTgxDAb215ZaO_zJrXGAhXXGuTYOjqzEFAh92o0Ec/edit#gid=1055116575)

1度~10度ズレた状態で角度補正を行い，それぞれ補正後の角度を計測した．
検証の結果，3度以上ズレの時に角度補正を行うと，補正前よりは角度のズレが少なくなっていることが分かった．
1度と2度においても，9割は角度のズレが少なくなっているが，2度程度のズレであれば次の動作に大きな影響を及ぼすことはなく，補正するメリットが薄いと考え，補正免除角度は2度に設定した．